### PR TITLE
feat: add codemods for `es-*`

### DIFF
--- a/codemods/es-define-property/index.js
+++ b/codemods/es-define-property/index.js
@@ -1,0 +1,46 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'es-define-property',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			let dirtyFlag = false;
+
+			const { identifier } = removeImport('es-define-property', root, j);
+
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.value.arguments;
+					const newExpression = j.callExpression(
+						j.memberExpression(
+							j.identifier('Object'),
+							j.identifier('defineProperty'),
+						),
+						args,
+					);
+					j(path).replaceWith(newExpression);
+					dirtyFlag = true;
+				});
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/codemods/es-get-iterator/index.js
+++ b/codemods/es-get-iterator/index.js
@@ -1,0 +1,50 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'es-get-iterator',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			let dirtyFlag = false;
+
+			const { identifier } = removeImport('es-get-iterator', root, j);
+
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.value.arguments;
+					const newExpression = j.optionalCallExpression(
+						j.memberExpression(
+							// @ts-expect-error
+							args[0],
+							j.memberExpression(
+								j.identifier('Symbol'),
+								j.identifier('iterator'),
+							),
+						),
+						[],
+					);
+					j(path).replaceWith(newExpression);
+					dirtyFlag = true;
+				});
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/codemods/es-get-iterator/index.js
+++ b/codemods/es-get-iterator/index.js
@@ -29,10 +29,12 @@ export default function (options) {
 				})
 				.forEach((path) => {
 					const args = path.value.arguments;
+					const arg =
+						args[0].type === 'SpreadElement' ? args[0].argument : args[0];
+
 					const newExpression = j.optionalCallExpression(
 						j.memberExpression(
-							// @ts-expect-error
-							args[0],
+							arg,
 							j.memberExpression(
 								j.identifier('Symbol'),
 								j.identifier('iterator'),

--- a/codemods/es-set-tostringtag/index.js
+++ b/codemods/es-set-tostringtag/index.js
@@ -29,6 +29,9 @@ export default function (options) {
 				})
 				.forEach((path) => {
 					const args = path.value.arguments;
+					const arg =
+						args[1].type === 'SpreadElement' ? args[1].argument : args[1];
+
 					const newExpression = j.callExpression(
 						j.memberExpression(
 							j.identifier('Object'),
@@ -46,8 +49,7 @@ export default function (options) {
 									j.identifier('configurable'),
 									j.booleanLiteral(true),
 								),
-								// @ts-expect-error
-								j.property('init', j.identifier('value'), args[1]),
+								j.property('init', j.identifier('value'), arg),
 							]),
 						],
 					);

--- a/codemods/es-set-tostringtag/index.js
+++ b/codemods/es-set-tostringtag/index.js
@@ -76,8 +76,14 @@ export default function (options) {
 									j.identifier('configurable'),
 									j.literal(true),
 								),
+								j.property(
+									'init',
+									j.identifier('enumerable'),
+									j.literal(false),
+								),
 								// @ts-ignore
 								j.property('init', j.identifier('value'), tag),
+								j.property('init', j.identifier('writable'), j.literal(false)),
 							]),
 						],
 					);

--- a/codemods/es-set-tostringtag/index.js
+++ b/codemods/es-set-tostringtag/index.js
@@ -1,0 +1,61 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'es-set-tostringtag',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			let dirtyFlag = false;
+
+			const { identifier } = removeImport('es-set-tostringtag', root, j);
+
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.value.arguments;
+					const newExpression = j.callExpression(
+						j.memberExpression(
+							j.identifier('Object'),
+							j.identifier('defineProperty'),
+						),
+						[
+							args[0],
+							j.memberExpression(
+								j.identifier('Symbol'),
+								j.identifier('toStringTag'),
+							),
+							j.objectExpression([
+								j.property(
+									'init',
+									j.identifier('configurable'),
+									j.booleanLiteral(true),
+								),
+								// @ts-expect-error
+								j.property('init', j.identifier('value'), args[1]),
+							]),
+						],
+					);
+					j(path).replaceWith(newExpression);
+					dirtyFlag = true;
+				});
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/test/fixtures/es-define-property/case-1/after.js
+++ b/test/fixtures/es-define-property/case-1/after.js
@@ -1,0 +1,27 @@
+const assert = require("assert");
+
+const o = { a: 1 };
+
+Object.defineProperty(o, "b", { enumerable: true, value: 2 });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "b"),
+  {
+    configurable: false,
+    enumerable: true,
+    value: 2,
+    writable: false,
+  },
+  "property descriptor is as expected"
+);
+
+Object.defineProperty(o, "c", { enumerable: false, value: 3, writable: true });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "c"),
+  {
+    configurable: false,
+    enumerable: false,
+    value: 3,
+    writable: true,
+  },
+  "property descriptor is as expected"
+);

--- a/test/fixtures/es-define-property/case-1/before.js
+++ b/test/fixtures/es-define-property/case-1/before.js
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const $defineProperty = require("es-define-property");
+
+const o = { a: 1 };
+
+$defineProperty(o, "b", { enumerable: true, value: 2 });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "b"),
+  {
+    configurable: false,
+    enumerable: true,
+    value: 2,
+    writable: false,
+  },
+  "property descriptor is as expected"
+);
+
+$defineProperty(o, "c", { enumerable: false, value: 3, writable: true });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "c"),
+  {
+    configurable: false,
+    enumerable: false,
+    value: 3,
+    writable: true,
+  },
+  "property descriptor is as expected"
+);

--- a/test/fixtures/es-define-property/case-1/result.js
+++ b/test/fixtures/es-define-property/case-1/result.js
@@ -1,0 +1,27 @@
+const assert = require("assert");
+
+const o = { a: 1 };
+
+Object.defineProperty(o, "b", { enumerable: true, value: 2 });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "b"),
+  {
+    configurable: false,
+    enumerable: true,
+    value: 2,
+    writable: false,
+  },
+  "property descriptor is as expected"
+);
+
+Object.defineProperty(o, "c", { enumerable: false, value: 3, writable: true });
+assert.deepEqual(
+  Object.getOwnPropertyDescriptor(o, "c"),
+  {
+    configurable: false,
+    enumerable: false,
+    value: 3,
+    writable: true,
+  },
+  "property descriptor is as expected"
+);

--- a/test/fixtures/es-get-iterator/case-1/after.js
+++ b/test/fixtures/es-get-iterator/case-1/after.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+const iterator1 = 'a 💩'[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator1.next(), iterator1.next(), iterator1.next(), iterator1.next()],
+	[{ done: false, value: 'a' }, { done: false, value: ' ' }, { done: false, value: '💩' }, { done: true, value: undefined }]
+);
+
+const iterator2 = [1, 2][Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator2.next(), iterator2.next(), iterator2.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator3 = new Set([1, 2])[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator3.next(), iterator3.next(), iterator3.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator4 = new Map([[1, 2], [3, 4]])[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator4.next(), iterator4.next(), iterator4.next()],
+	[{ done: false, value: [1, 2] }, { done: false, value: [3, 4] }, { done: true, value: undefined }]
+);

--- a/test/fixtures/es-get-iterator/case-1/before.js
+++ b/test/fixtures/es-get-iterator/case-1/before.js
@@ -1,0 +1,26 @@
+const getIterator = require('es-get-iterator');
+const assert = require('assert');
+
+const iterator1 = getIterator('a 💩');
+assert.deepEqual(
+	[iterator1.next(), iterator1.next(), iterator1.next(), iterator1.next()],
+	[{ done: false, value: 'a' }, { done: false, value: ' ' }, { done: false, value: '💩' }, { done: true, value: undefined }]
+);
+
+const iterator2 = getIterator([1, 2]);
+assert.deepEqual(
+	[iterator2.next(), iterator2.next(), iterator2.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator3 = getIterator(new Set([1, 2]));
+assert.deepEqual(
+	[iterator3.next(), iterator3.next(), iterator3.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator4 = getIterator(new Map([[1, 2], [3, 4]]));
+assert.deepEqual(
+	[iterator4.next(), iterator4.next(), iterator4.next()],
+	[{ done: false, value: [1, 2] }, { done: false, value: [3, 4] }, { done: true, value: undefined }]
+);

--- a/test/fixtures/es-get-iterator/case-1/result.js
+++ b/test/fixtures/es-get-iterator/case-1/result.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+const iterator1 = 'a 💩'[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator1.next(), iterator1.next(), iterator1.next(), iterator1.next()],
+	[{ done: false, value: 'a' }, { done: false, value: ' ' }, { done: false, value: '💩' }, { done: true, value: undefined }]
+);
+
+const iterator2 = [1, 2][Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator2.next(), iterator2.next(), iterator2.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator3 = new Set([1, 2])[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator3.next(), iterator3.next(), iterator3.next()],
+	[{ done: false, value: 1 }, { done: false, value: 2 }, { done: true, value: undefined }]
+);
+
+const iterator4 = new Map([[1, 2], [3, 4]])[Symbol.iterator]?.();
+assert.deepEqual(
+	[iterator4.next(), iterator4.next(), iterator4.next()],
+	[{ done: false, value: [1, 2] }, { done: false, value: [3, 4] }, { done: true, value: undefined }]
+);

--- a/test/fixtures/es-set-tostringtag/case-1/after.js
+++ b/test/fixtures/es-set-tostringtag/case-1/after.js
@@ -5,7 +5,7 @@ const sentinel = {};
 
 Object.defineProperty(obj, Symbol.toStringTag, {
   configurable: true,
-  value: sentinel,
+  value: sentinel
 });
 
 assert.equal(
@@ -22,7 +22,7 @@ assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
 Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
-  value: "new tag",
+  value: "new tag"
 });
 assert.equal(
   String(tagged),

--- a/test/fixtures/es-set-tostringtag/case-1/after.js
+++ b/test/fixtures/es-set-tostringtag/case-1/after.js
@@ -5,7 +5,9 @@ const sentinel = {};
 
 !Object.hasOwn(obj, Symbol.toStringTag) && Object.defineProperty(obj, Symbol.toStringTag, {
   configurable: true,
-  value: 'sentinel'
+  enumerable: false,
+  value: 'sentinel',
+  writable: false
 });
 
 assert.equal(
@@ -22,7 +24,9 @@ assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
 !Object.hasOwn(tagged, Symbol.toStringTag) && Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
-  value: "new tag"
+  enumerable: false,
+  value: "new tag",
+  writable: false
 });
 assert.equal(
   String(tagged),
@@ -32,7 +36,9 @@ assert.equal(
 
 Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
-  value: 'new tag'
+  enumerable: false,
+  value: 'new tag',
+  writable: false
 });
 assert.equal(
   String(tagged),

--- a/test/fixtures/es-set-tostringtag/case-1/after.js
+++ b/test/fixtures/es-set-tostringtag/case-1/after.js
@@ -1,0 +1,31 @@
+const assert = require("assert");
+
+const obj = {};
+const sentinel = {};
+
+Object.defineProperty(obj, Symbol.toStringTag, {
+  configurable: true,
+  value: sentinel,
+});
+
+assert.equal(
+  obj[Symbol.toStringTag],
+  sentinel,
+  "toStringTag property is as expected"
+);
+
+assert.equal(String(obj), "[object Object]", "toStringTag works");
+
+var tagged = {};
+tagged[Symbol.toStringTag] = "already tagged";
+assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
+
+Object.defineProperty(tagged, Symbol.toStringTag, {
+  configurable: true,
+  value: "new tag",
+});
+assert.equal(
+  String(tagged),
+  "[object already tagged]",
+  "toStringTag is unchanged"
+);

--- a/test/fixtures/es-set-tostringtag/case-1/after.js
+++ b/test/fixtures/es-set-tostringtag/case-1/after.js
@@ -3,9 +3,9 @@ const assert = require("assert");
 const obj = {};
 const sentinel = {};
 
-Object.defineProperty(obj, Symbol.toStringTag, {
+!Object.hasOwn(obj, Symbol.toStringTag) && Object.defineProperty(obj, Symbol.toStringTag, {
   configurable: true,
-  value: sentinel
+  value: 'sentinel'
 });
 
 assert.equal(
@@ -16,16 +16,26 @@ assert.equal(
 
 assert.equal(String(obj), "[object Object]", "toStringTag works");
 
-var tagged = {};
+const tagged = {};
 tagged[Symbol.toStringTag] = "already tagged";
 assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
-Object.defineProperty(tagged, Symbol.toStringTag, {
+!Object.hasOwn(tagged, Symbol.toStringTag) && Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
   value: "new tag"
 });
 assert.equal(
   String(tagged),
   "[object already tagged]",
+  "toStringTag is unchanged"
+);
+
+Object.defineProperty(tagged, Symbol.toStringTag, {
+  configurable: true,
+  value: 'new tag'
+});
+assert.equal(
+  String(tagged),
+  "[object new tag]",
   "toStringTag is unchanged"
 );

--- a/test/fixtures/es-set-tostringtag/case-1/before.js
+++ b/test/fixtures/es-set-tostringtag/case-1/before.js
@@ -4,7 +4,7 @@ const setToStringTag = require("es-set-tostringtag");
 const obj = {};
 const sentinel = {};
 
-setToStringTag(obj, sentinel);
+setToStringTag(obj, 'sentinel');
 
 assert.equal(
   obj[Symbol.toStringTag],
@@ -14,7 +14,7 @@ assert.equal(
 
 assert.equal(String(obj), "[object Object]", "toStringTag works");
 
-var tagged = {};
+const tagged = {};
 tagged[Symbol.toStringTag] = "already tagged";
 assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
@@ -22,5 +22,12 @@ setToStringTag(tagged, "new tag");
 assert.equal(
   String(tagged),
   "[object already tagged]",
+  "toStringTag is unchanged"
+);
+
+setToStringTag(tagged, 'new tag', { force: true });
+assert.equal(
+  String(tagged),
+  "[object new tag]",
   "toStringTag is unchanged"
 );

--- a/test/fixtures/es-set-tostringtag/case-1/before.js
+++ b/test/fixtures/es-set-tostringtag/case-1/before.js
@@ -1,0 +1,26 @@
+const assert = require("assert");
+const setToStringTag = require("es-set-tostringtag");
+
+const obj = {};
+const sentinel = {};
+
+setToStringTag(obj, sentinel);
+
+assert.equal(
+  obj[Symbol.toStringTag],
+  sentinel,
+  "toStringTag property is as expected"
+);
+
+assert.equal(String(obj), "[object Object]", "toStringTag works");
+
+var tagged = {};
+tagged[Symbol.toStringTag] = "already tagged";
+assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
+
+setToStringTag(tagged, "new tag");
+assert.equal(
+  String(tagged),
+  "[object already tagged]",
+  "toStringTag is unchanged"
+);

--- a/test/fixtures/es-set-tostringtag/case-1/result.js
+++ b/test/fixtures/es-set-tostringtag/case-1/result.js
@@ -1,0 +1,31 @@
+const assert = require("assert");
+
+const obj = {};
+const sentinel = {};
+
+Object.defineProperty(obj, Symbol.toStringTag, {
+  configurable: true,
+  value: sentinel
+});
+
+assert.equal(
+  obj[Symbol.toStringTag],
+  sentinel,
+  "toStringTag property is as expected"
+);
+
+assert.equal(String(obj), "[object Object]", "toStringTag works");
+
+var tagged = {};
+tagged[Symbol.toStringTag] = "already tagged";
+assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
+
+Object.defineProperty(tagged, Symbol.toStringTag, {
+  configurable: true,
+  value: "new tag"
+});
+assert.equal(
+  String(tagged),
+  "[object already tagged]",
+  "toStringTag is unchanged"
+);

--- a/test/fixtures/es-set-tostringtag/case-1/result.js
+++ b/test/fixtures/es-set-tostringtag/case-1/result.js
@@ -5,7 +5,9 @@ const sentinel = {};
 
 !Object.hasOwn(obj, Symbol.toStringTag) && Object.defineProperty(obj, Symbol.toStringTag, {
   configurable: true,
-  value: 'sentinel'
+  enumerable: false,
+  value: 'sentinel',
+  writable: false
 });
 
 assert.equal(
@@ -22,7 +24,9 @@ assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
 !Object.hasOwn(tagged, Symbol.toStringTag) && Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
-  value: "new tag"
+  enumerable: false,
+  value: "new tag",
+  writable: false
 });
 assert.equal(
   String(tagged),
@@ -32,7 +36,9 @@ assert.equal(
 
 Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
-  value: 'new tag'
+  enumerable: false,
+  value: 'new tag',
+  writable: false
 });
 assert.equal(
   String(tagged),

--- a/test/fixtures/es-set-tostringtag/case-1/result.js
+++ b/test/fixtures/es-set-tostringtag/case-1/result.js
@@ -3,9 +3,9 @@ const assert = require("assert");
 const obj = {};
 const sentinel = {};
 
-Object.defineProperty(obj, Symbol.toStringTag, {
+!Object.hasOwn(obj, Symbol.toStringTag) && Object.defineProperty(obj, Symbol.toStringTag, {
   configurable: true,
-  value: sentinel
+  value: 'sentinel'
 });
 
 assert.equal(
@@ -16,16 +16,26 @@ assert.equal(
 
 assert.equal(String(obj), "[object Object]", "toStringTag works");
 
-var tagged = {};
+const tagged = {};
 tagged[Symbol.toStringTag] = "already tagged";
 assert.equal(String(tagged), "[object already tagged]", "toStringTag works");
 
-Object.defineProperty(tagged, Symbol.toStringTag, {
+!Object.hasOwn(tagged, Symbol.toStringTag) && Object.defineProperty(tagged, Symbol.toStringTag, {
   configurable: true,
   value: "new tag"
 });
 assert.equal(
   String(tagged),
   "[object already tagged]",
+  "toStringTag is unchanged"
+);
+
+Object.defineProperty(tagged, Symbol.toStringTag, {
+  configurable: true,
+  value: 'new tag'
+});
+assert.equal(
+  String(tagged),
+  "[object new tag]",
   "toStringTag is unchanged"
 );


### PR DESCRIPTION
Add the following codemods

- `es-get-iterator`
- `es-set-tostringtag`
- `es-define-property`

I'm not too familiar with `jscodeshift` so I'm not sure if there are problems with my codemods.

Also, I had some type errors. I'm not sure if this is expected or if it can be fixed