### PR TITLE
fix(is-npm): support more ways of importing + non-standard import names

### DIFF
--- a/test/fixtures/is-npm/case-2/after.js
+++ b/test/fixtures/is-npm/case-2/after.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-2/before.js
+++ b/test/fixtures/is-npm/case-2/before.js
@@ -1,0 +1,5 @@
+import { isNpm as banana, isYarn as pear, isNpmOrYarn as strawberry } from 'is-npm';
+
+console.log(banana);
+console.log(pear);
+console.log(strawberry);

--- a/test/fixtures/is-npm/case-2/result.js
+++ b/test/fixtures/is-npm/case-2/result.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-3/after.js
+++ b/test/fixtures/is-npm/case-3/after.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-3/before.js
+++ b/test/fixtures/is-npm/case-3/before.js
@@ -1,0 +1,5 @@
+import * as banana from 'is-npm';
+
+console.log(banana.isNpm);
+console.log(banana.isYarn);
+console.log(banana.isNpmOrYarn);

--- a/test/fixtures/is-npm/case-3/result.js
+++ b/test/fixtures/is-npm/case-3/result.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-4/after.js
+++ b/test/fixtures/is-npm/case-4/after.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-4/before.js
+++ b/test/fixtures/is-npm/case-4/before.js
@@ -1,0 +1,5 @@
+const { isNpm: banana, isYarn: pear, isNpmOrYarn: strawberry } = require('is-npm');
+
+console.log(banana);
+console.log(pear);
+console.log(strawberry);

--- a/test/fixtures/is-npm/case-4/result.js
+++ b/test/fixtures/is-npm/case-4/result.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-5/after.js
+++ b/test/fixtures/is-npm/case-5/after.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));

--- a/test/fixtures/is-npm/case-5/before.js
+++ b/test/fixtures/is-npm/case-5/before.js
@@ -1,0 +1,5 @@
+const banana = require('is-npm');
+
+console.log(banana.isNpm);
+console.log(banana.isYarn);
+console.log(banana.isNpmOrYarn);

--- a/test/fixtures/is-npm/case-5/result.js
+++ b/test/fixtures/is-npm/case-5/result.js
@@ -1,0 +1,3 @@
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));
+console.log(process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("npm") || process.env.npm_package_json && process.env.npm_package_json.endsWith("package.json") || process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn"));


### PR DESCRIPTION
Currently, the `is-npm` codemod assumes that developers name the imported members `isNpm`, `isYarn` and `isYarnOrNpm`. However, there are two ways in which developers could alter the imports that can't be handled by the codemod:

```js
// ESM
import { isNpm as banana, isYarn as pear, isNpmOrYarn as strawberry } from 'is-npm';
import * as banana from 'is-npm';

// CJS
const { isNpm: banana, isYarn: pear, isNpmOrYarn: strawberry } = require('is-npm');
const banana = require('is-npm');
```

Moreover, by relying on hardcoded names, we also could potentially make unsafe modifications to developer code (they could have an `isNpm` variable themselves which is different from the imported one and has a different meaning)

This PR makes the codemod detect the imported names dynamically so that it supports the styles above. It also adds test cases to handle the new styles.

The PR introduces the `getImportIdentifierMap` helper which creates a map like this:

```js
// import { isNpm as banana, isYarn as pear, isNpmOrYarn as strawberry } from 'is-npm';
const map = {
  isNpm: "banana",
  isYarn: "pear",
  isNpmOrYarn: "strawberry"
}

// import * as banana from 'is-npm';
const map = {
  [Symbol(NAMEPSACE_IMPORT)]: "banana"
}
```

This helper should be useful for cases where a module exports multiple names and `const { identifier } = removeImport()` is not sufficient.

There is some duplication in the codemod code, as the "individual name import" and "namespace import" cases need to be handled separately. However, since I suspect that this issue will also apply to other codemods, I believe the duplication is fine for now — we can figure out better abstractions as we continue improving the mods.

Thanks for reading!