### PR TITLE
`clone-regexp`

### DIFF
--- a/codemods/clone-regexp/index.js
+++ b/codemods/clone-regexp/index.js
@@ -28,19 +28,15 @@ export default function (options) {
 				})
 				.replaceWith((path) => {
 					const args = path.node.arguments;
-					if (args.length === 0) {
-						return j.newExpression(j.identifier('RegExp'), []);
-					}
-					if (args.length === 1) {
-						return j.newExpression(j.identifier('RegExp'), [args[0]]);
-					}
+					const arg = args.length >= 1 ? [args[0]] : [];
+					const newRegExp = j.newExpression(j.identifier('RegExp'), arg);
 					if (args.length === 2) {
-						const newExpression = j.newExpression(j.identifier('RegExp'), [
-							args[0],
-						]);
-						newExpression.comments = [j.commentBlock(' Todo ', false, true)];
-						return newExpression;
+						console.warn(
+							'[WARNING] Options are being passed to `clone-regexp`. Please modify the new regular expression accordingly.',
+						);
+						newRegExp.comments = [j.commentBlock(' Todo ', false, true)];
 					}
+					return newRegExp;
 				})
 				.toSource({ quote: 'single' });
 		},

--- a/codemods/clone-regexp/index.js
+++ b/codemods/clone-regexp/index.js
@@ -1,0 +1,48 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'clone-regexp',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const { identifier } = removeImport('clone-regexp', root, j);
+
+			return root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.replaceWith((path) => {
+					const args = path.node.arguments;
+					if (args.length === 0) {
+						return j.newExpression(j.identifier('RegExp'), []);
+					}
+					if (args.length === 1) {
+						return j.newExpression(j.identifier('RegExp'), [args[0]]);
+					}
+					if (args.length === 2) {
+						const newExpression = j.newExpression(j.identifier('RegExp'), [
+							args[0],
+						]);
+						newExpression.comments = [j.commentBlock(' Todo ', false, true)];
+						return newExpression;
+					}
+				})
+				.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/codemods/clone-regexp/index.js
+++ b/codemods/clone-regexp/index.js
@@ -30,7 +30,7 @@ export default function (options) {
 					const args = path.node.arguments;
 					const arg = args.length >= 1 ? [args[0]] : [];
 					const newRegExp = j.newExpression(j.identifier('RegExp'), arg);
-					if (args.length === 2) {
+					if (args.length >= 2) {
 						console.warn(
 							'[WARNING] Options are being passed to `clone-regexp`. Please modify the new regular expression accordingly.',
 						);

--- a/test/fixtures/clone-regexp/case-1/after.js
+++ b/test/fixtures/clone-regexp/case-1/after.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = new RegExp(/[a-z]/gi);
+assert.deepStrictEqual(regex, clone1);
+assert.ok(regex !== clone1)
+
+// Argument is an identifier
+const clone2 = new RegExp(regex);
+assert.deepStrictEqual(regex, clone2);
+assert.ok(regex !== clone2);

--- a/test/fixtures/clone-regexp/case-1/before.js
+++ b/test/fixtures/clone-regexp/case-1/before.js
@@ -1,0 +1,14 @@
+import cloneRegexp from 'clone-regexp';
+import assert from 'assert';
+
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = cloneRegexp(/[a-z]/gi);
+assert.deepStrictEqual(regex, clone1);
+assert.ok(regex !== clone1)
+
+// Argument is an identifier
+const clone2 = cloneRegexp(regex);
+assert.deepStrictEqual(regex, clone2);
+assert.ok(regex !== clone2);

--- a/test/fixtures/clone-regexp/case-1/result.js
+++ b/test/fixtures/clone-regexp/case-1/result.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = new RegExp(/[a-z]/gi);
+assert.deepStrictEqual(regex, clone1);
+assert.ok(regex !== clone1)
+
+// Argument is an identifier
+const clone2 = new RegExp(regex);
+assert.deepStrictEqual(regex, clone2);
+assert.ok(regex !== clone2);

--- a/test/fixtures/clone-regexp/case-2/after.js
+++ b/test/fixtures/clone-regexp/case-2/after.js
@@ -1,0 +1,17 @@
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = new RegExp(/[a-z]/gi)/* Todo */;
+
+// Argument is an identifier
+const clone2 = new RegExp(regex)/* Todo */;
+
+// Both arguments are identifier
+const opt = { ignoreCase: 1 === 1 };
+const clone3 = new RegExp(regex)/* Todo */;
+
+// Multiple cloneRegexp
+const clone4 = f(new RegExp(regex)/* Todo */, new RegExp(regex)/* Todo */);
+
+// Regex comes from a function
+const clone5 = new RegExp(f(regex))/* Todo */;

--- a/test/fixtures/clone-regexp/case-2/before.js
+++ b/test/fixtures/clone-regexp/case-2/before.js
@@ -1,0 +1,19 @@
+import cloneRegexp from 'clone-regexp';
+
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = cloneRegexp(/[a-z]/gi, { global: false });
+
+// Argument is an identifier
+const clone2 = cloneRegexp(regex, { unicode: true });
+
+// Both arguments are identifier
+const opt = { ignoreCase: 1 === 1 };
+const clone3 = cloneRegexp(regex, opt);
+
+// Multiple cloneRegexp
+const clone4 = f(cloneRegexp(regex, { sticky: true }), cloneRegexp(regex, { dotAll: true }));
+
+// Regex comes from a function
+const clone5 = cloneRegexp(f(regex), { multiline: true });

--- a/test/fixtures/clone-regexp/case-2/result.js
+++ b/test/fixtures/clone-regexp/case-2/result.js
@@ -1,0 +1,17 @@
+const regex = /[a-z]/gi;
+
+// Argument is a regex
+const clone1 = new RegExp(/[a-z]/gi)/* Todo */;
+
+// Argument is an identifier
+const clone2 = new RegExp(regex)/* Todo */;
+
+// Both arguments are identifier
+const opt = { ignoreCase: 1 === 1 };
+const clone3 = new RegExp(regex)/* Todo */;
+
+// Multiple cloneRegexp
+const clone4 = f(new RegExp(regex)/* Todo */, new RegExp(regex)/* Todo */);
+
+// Regex comes from a function
+const clone5 = new RegExp(f(regex))/* Todo */;

--- a/test/fixtures/clone-regexp/case-3/after.js
+++ b/test/fixtures/clone-regexp/case-3/after.js
@@ -1,0 +1,1 @@
+const clone1 = new RegExp();

--- a/test/fixtures/clone-regexp/case-3/before.js
+++ b/test/fixtures/clone-regexp/case-3/before.js
@@ -1,0 +1,3 @@
+import cloneRegexp from 'clone-regexp';
+
+const clone1 = cloneRegexp();

--- a/test/fixtures/clone-regexp/case-3/result.js
+++ b/test/fixtures/clone-regexp/case-3/result.js
@@ -1,0 +1,1 @@
+const clone1 = new RegExp();

--- a/test/fixtures/clone-regexp/case-4/after.js
+++ b/test/fixtures/clone-regexp/case-4/after.js
@@ -1,0 +1,1 @@
+const clone1 = new RegExp();

--- a/test/fixtures/clone-regexp/case-4/before.js
+++ b/test/fixtures/clone-regexp/case-4/before.js
@@ -1,0 +1,3 @@
+import myCloneRegexp from 'clone-regexp';
+
+const clone1 = myCloneRegexp();

--- a/test/fixtures/clone-regexp/case-4/result.js
+++ b/test/fixtures/clone-regexp/case-4/result.js
@@ -1,0 +1,1 @@
+const clone1 = new RegExp();


### PR DESCRIPTION
Package: https://www.npmjs.com/package/clone-regexp
Weekly Downloads: 1,870,645

The function `cloneRegexp` cannot be directly replaced by `new RegExp` because of the `options` argument. Instead, I use the following logic
- Options are not given: Replace `cloneRegexp(regex)` with `new RegExp(regex)`
- Options are given: Replace `cloneRegexp(regex, opt)` with `new RegExp(regex) /* Todo /*` which makes the developer responsible of ensuring the new code isn't breaking.