### PR TITLE
`symbol.prototype.description`

### DIFF
--- a/codemods/symbol.prototype.description/index.js
+++ b/codemods/symbol.prototype.description/index.js
@@ -1,0 +1,67 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'symbol.prototype.description',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			// Remove import/require statement
+			const { identifier } = removeImport(
+				'symbol.prototype.description',
+				root,
+				j,
+			);
+
+			// Remove description.shim()
+			root
+				.find(j.ExpressionStatement, {
+					expression: {
+						callee: {
+							type: 'MemberExpression',
+							object: { name: identifier },
+							property: { name: 'shim' },
+						},
+					},
+				})
+				.forEach((path) => {
+					j(path).remove();
+				});
+
+			// Replace description(Symbol('foo')) with Symbol('foo').description
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.node.arguments;
+					const newArgs =
+						args.length === 1 && j.CallExpression.check(args[0])
+							? args[0].arguments
+							: [];
+					path.replace(
+						j.memberExpression(
+							j.callExpression(j.identifier('Symbol'), newArgs),
+							j.identifier('description'),
+						),
+					);
+				});
+
+			return root.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/test/fixtures/symbol.prototype.description/case-1/after.js
+++ b/test/fixtures/symbol.prototype.description/case-1/after.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(Symbol('foo').description === 'foo');
+assert(Symbol().description === undefined);
+assert(Symbol(undefined).description === undefined);
+assert(Symbol(null).description === 'null');

--- a/test/fixtures/symbol.prototype.description/case-1/before.js
+++ b/test/fixtures/symbol.prototype.description/case-1/before.js
@@ -1,0 +1,7 @@
+var description = require('symbol.prototype.description');
+var assert = require('assert');
+
+assert(description(Symbol('foo')) === 'foo');
+assert(description(Symbol()) === undefined);
+assert(description(Symbol(undefined)) === undefined);
+assert(description(Symbol(null)) === 'null');

--- a/test/fixtures/symbol.prototype.description/case-1/result.js
+++ b/test/fixtures/symbol.prototype.description/case-1/result.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(Symbol('foo').description === 'foo');
+assert(Symbol().description === undefined);
+assert(Symbol(undefined).description === undefined);
+assert(Symbol(null).description === 'null');

--- a/test/fixtures/symbol.prototype.description/case-2/after.js
+++ b/test/fixtures/symbol.prototype.description/case-2/after.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(Symbol('foo').description === Symbol('foo').description);
+assert(Symbol().description === Symbol().description);
+assert(Symbol(undefined).description === Symbol(undefined).description);
+assert(Symbol(null).description === Symbol(null).description);

--- a/test/fixtures/symbol.prototype.description/case-2/before.js
+++ b/test/fixtures/symbol.prototype.description/case-2/before.js
@@ -1,0 +1,8 @@
+var description = require('symbol.prototype.description');
+var assert = require('assert');
+
+description.shim();
+assert(description(Symbol('foo')) === Symbol('foo').description);
+assert(description(Symbol()) === Symbol().description);
+assert(description(Symbol(undefined)) === Symbol(undefined).description);
+assert(description(Symbol(null)) === Symbol(null).description);

--- a/test/fixtures/symbol.prototype.description/case-2/result.js
+++ b/test/fixtures/symbol.prototype.description/case-2/result.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(Symbol('foo').description === Symbol('foo').description);
+assert(Symbol().description === Symbol().description);
+assert(Symbol(undefined).description === Symbol(undefined).description);
+assert(Symbol(null).description === Symbol(null).description);


### PR DESCRIPTION
Module: [`symbol.prototype.description`](https://www.npmjs.com/package/symbol.prototype.description)
Weekly Downloads: 1,437,366

- Remove import
- Remove `description.shim()`
- Replace `description(Symbol('foo'))` with `Symbol('foo').description`