### PR TITLE
`regexp.prototype.flags`

### DIFF
--- a/codemods/regexp.prototype.flags/index.js
+++ b/codemods/regexp.prototype.flags/index.js
@@ -1,0 +1,57 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'regexp.prototype.flags',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			// Remove import/require statement
+			const { identifier } = removeImport('regexp.prototype.flags', root, j);
+
+			// Remove flags.shim()
+			root
+				.find(j.ExpressionStatement, {
+					expression: {
+						callee: {
+							type: 'MemberExpression',
+							object: { name: identifier },
+							property: { name: 'shim' },
+						},
+					},
+				})
+				.forEach((path) => {
+					j(path).remove();
+				});
+
+			// Replace flags(arg) with arg.flags
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					const args = path.node.arguments;
+					if (args.length !== 1) return; // flags takes exactly one argument
+					if (j.Expression.check(args[0]) && !j.SpreadElement.check(args[0])) {
+						path.replace(j.memberExpression(args[0], j.identifier('flags')));
+					}
+				});
+
+			return root.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/test/fixtures/regexp.prototype.flags/case-1/after.js
+++ b/test/fixtures/regexp.prototype.flags/case-1/after.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(/a/.flags === '');
+assert(new RegExp('a').flags === '');
+assert(/a/mig.flags === 'gim');
+assert(new RegExp('a', 'mig').flags === 'gim');

--- a/test/fixtures/regexp.prototype.flags/case-1/before.js
+++ b/test/fixtures/regexp.prototype.flags/case-1/before.js
@@ -1,0 +1,7 @@
+var flags = require('regexp.prototype.flags');
+var assert = require('assert');
+
+assert(flags(/a/) === '');
+assert(flags(new RegExp('a')) === '');
+assert(flags(/a/mig) === 'gim');
+assert(flags(new RegExp('a', 'mig')) === 'gim');

--- a/test/fixtures/regexp.prototype.flags/case-1/result.js
+++ b/test/fixtures/regexp.prototype.flags/case-1/result.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(/a/.flags === '');
+assert(new RegExp('a').flags === '');
+assert(/a/mig.flags === 'gim');
+assert(new RegExp('a', 'mig').flags === 'gim');

--- a/test/fixtures/regexp.prototype.flags/case-2/after.js
+++ b/test/fixtures/regexp.prototype.flags/case-2/after.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(/a/.flags === /a/.flags);
+assert(new RegExp('a').flags === new RegExp('a').flags);
+assert(/a/mig.flags === /a/mig.flags);
+assert(new RegExp('a', 'mig').flags === new RegExp('a', 'mig').flags);

--- a/test/fixtures/regexp.prototype.flags/case-2/before.js
+++ b/test/fixtures/regexp.prototype.flags/case-2/before.js
@@ -1,0 +1,8 @@
+var flags = require('regexp.prototype.flags');
+var assert = require('assert');
+
+flags.shim();
+assert(flags(/a/) === /a/.flags);
+assert(flags(new RegExp('a')) === new RegExp('a').flags);
+assert(flags(/a/mig) === /a/mig.flags);
+assert(flags(new RegExp('a', 'mig')) === new RegExp('a', 'mig').flags);

--- a/test/fixtures/regexp.prototype.flags/case-2/result.js
+++ b/test/fixtures/regexp.prototype.flags/case-2/result.js
@@ -1,0 +1,6 @@
+var assert = require('assert');
+
+assert(/a/.flags === /a/.flags);
+assert(new RegExp('a').flags === new RegExp('a').flags);
+assert(/a/mig.flags === /a/mig.flags);
+assert(new RegExp('a', 'mig').flags === new RegExp('a', 'mig').flags);

--- a/test/fixtures/regexp.prototype.flags/case-3/after.js
+++ b/test/fixtures/regexp.prototype.flags/case-3/after.js
@@ -1,0 +1,7 @@
+var assert = require('assert');
+
+function getRegex() {
+    return /a/;
+}
+
+assert(getRegex().flags === '');

--- a/test/fixtures/regexp.prototype.flags/case-3/before.js
+++ b/test/fixtures/regexp.prototype.flags/case-3/before.js
@@ -1,0 +1,8 @@
+var flags = require('regexp.prototype.flags');
+var assert = require('assert');
+
+function getRegex() {
+    return /a/;
+}
+
+assert(flags(getRegex()) === '');

--- a/test/fixtures/regexp.prototype.flags/case-3/result.js
+++ b/test/fixtures/regexp.prototype.flags/case-3/result.js
@@ -1,0 +1,7 @@
+var assert = require('assert');
+
+function getRegex() {
+    return /a/;
+}
+
+assert(getRegex().flags === '');


### PR DESCRIPTION
Package: [regexp.prototype.flags](https://www.npmjs.com/package/regexp.prototype.flags)
Weekly Downloads: 33,652,934

- Remove `import`/`require` statement
- Remove `flags.shim()`
- Replace `flags(arg)` with `arg.flags`