### PR TITLE
`es-shim-unscopables`

### DIFF
--- a/codemods/es-shim-unscopables/index.js
+++ b/codemods/es-shim-unscopables/index.js
@@ -1,0 +1,36 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'es-shim-unscopables',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const { identifier } = removeImport('es-shim-unscopables', root, j);
+
+			root
+				.find(j.CallExpression, {
+					callee: {
+						type: 'Identifier',
+						name: identifier,
+					},
+				})
+				.forEach((path) => {
+					j(path).remove();
+				});
+
+			return root.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/test/fixtures/es-shim-unscopables/case-1/after.js
+++ b/test/fixtures/es-shim-unscopables/case-1/after.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+
+let includes;
+assert.notEqual(includes, Array.prototype.includes);
+assert.notEqual(includes, Array.prototype.includes);

--- a/test/fixtures/es-shim-unscopables/case-1/before.js
+++ b/test/fixtures/es-shim-unscopables/case-1/before.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const shimUnscopables = require('es-shim-unscopables');
+
+let includes;
+assert.notEqual(includes, Array.prototype.includes);
+shimUnscopables('includes');
+assert.notEqual(includes, Array.prototype.includes);

--- a/test/fixtures/es-shim-unscopables/case-1/result.js
+++ b/test/fixtures/es-shim-unscopables/case-1/result.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+
+let includes;
+assert.notEqual(includes, Array.prototype.includes);
+assert.notEqual(includes, Array.prototype.includes);

--- a/test/fixtures/es-shim-unscopables/case-2/after.js
+++ b/test/fixtures/es-shim-unscopables/case-2/after.js
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/test/fixtures/es-shim-unscopables/case-2/before.js
+++ b/test/fixtures/es-shim-unscopables/case-2/before.js
@@ -1,0 +1,7 @@
+const shimUnscopables = require('es-shim-unscopables');
+
+shimUnscopables('includes');
+shimUnscopables('concat');
+shimUnscopables('copyWithin');
+
+console.log('Hello World');

--- a/test/fixtures/es-shim-unscopables/case-2/result.js
+++ b/test/fixtures/es-shim-unscopables/case-2/result.js
@@ -1,0 +1,1 @@
+console.log('Hello World');


### PR DESCRIPTION
Package [`es-shim-unscopables`](https://www.npmjs.com/package/es-shim-unscopables)
Weekly Downloads: 22,405,560

If I understood the package correctly, we just need to remove the import and any `shimUnscopables('...')` call. 