### PR TITLE
`es-string-html-methods`

### DIFF
--- a/codemods/es-string-html-methods/index.js
+++ b/codemods/es-string-html-methods/index.js
@@ -1,0 +1,82 @@
+import jscodeshift from 'jscodeshift';
+import { removeImport } from '../shared.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'es-string-html-methods',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+
+			const methods = [
+				'anchor',
+				'big',
+				'blink',
+				'bold',
+				'fixed',
+				'fontcolor',
+				'fontsize',
+				'italics',
+				'link',
+				'small',
+				'strike',
+				'sub',
+				'sup',
+			];
+
+			// Remove all imports
+			const methodIdentifiers = methods.reduce((acc, method) => {
+				//@ts-ignore
+				acc[method] = removeImport(
+					`es-string-html-methods/${method}`,
+					root,
+					j,
+				).identifier;
+				return acc;
+			}, {});
+			methods.forEach((method) => {
+				removeImport(`es-string-html-methods/${method}/auto`, root, j);
+			});
+			removeImport('es-string-html-methods/auto', root, j);
+
+			// Replace all calls, e.g. blink('foo') -> 'foo'.blink()
+			methods.forEach((method) => {
+				root
+					.find(j.CallExpression, {
+						callee: {
+							type: 'Identifier',
+							//@ts-ignore
+							name: methodIdentifiers[method],
+						},
+					})
+					.forEach((path) => {
+						const args = path.node.arguments;
+						if (args.length === 0) return;
+						if (
+							j.Expression.check(args[0]) &&
+							!j.SpreadElement.check(args[0])
+						) {
+							const additionalArgs = args.length > 1 ? [args[1]] : [];
+							path.replace(
+								j.memberExpression(
+									args[0],
+									j.callExpression(j.identifier(method), additionalArgs),
+								),
+							);
+						}
+					});
+			});
+
+			return root.toSource({ quote: 'single' });
+		},
+	};
+}

--- a/codemods/es-string-html-methods/index.js
+++ b/codemods/es-string-html-methods/index.js
@@ -34,15 +34,11 @@ export default function (options) {
 			];
 
 			// Remove all imports
-			const methodIdentifiers = methods.reduce((acc, method) => {
-				//@ts-ignore
-				acc[method] = removeImport(
-					`es-string-html-methods/${method}`,
-					root,
-					j,
-				).identifier;
-				return acc;
-			}, {});
+			const entries = methods.map((method) => [
+				method,
+				removeImport(`es-string-html-methods/${method}`, root, j).identifier,
+			]);
+			const methodIdentifiers = Object.fromEntries(entries);
 			methods.forEach((method) => {
 				removeImport(`es-string-html-methods/${method}/auto`, root, j);
 			});
@@ -54,7 +50,6 @@ export default function (options) {
 					.find(j.CallExpression, {
 						callee: {
 							type: 'Identifier',
-							//@ts-ignore
 							name: methodIdentifiers[method],
 						},
 					})

--- a/test/fixtures/es-string-html-methods/case-1/after.js
+++ b/test/fixtures/es-string-html-methods/case-1/after.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-1/before.js
+++ b/test/fixtures/es-string-html-methods/case-1/before.js
@@ -1,0 +1,28 @@
+var anchor = require('es-string-html-methods/anchor');
+var big = require('es-string-html-methods/big');
+var blink = require('es-string-html-methods/blink');
+var bold = require('es-string-html-methods/bold');
+var fixed = require('es-string-html-methods/fixed');
+var fontcolor = require('es-string-html-methods/fontcolor');
+var fontsize = require('es-string-html-methods/fontsize');
+var italics = require('es-string-html-methods/italics');
+var link = require('es-string-html-methods/link');
+var small = require('es-string-html-methods/small');
+var strike = require('es-string-html-methods/strike');
+var sub = require('es-string-html-methods/sub');
+var sup = require('es-string-html-methods/sup');
+var assert = require('assert');
+
+assert.equal(anchor('a', 'b'), '<a name="b">a</a>');
+assert.equal(big('a'), '<big>a</big>');
+assert.equal(blink('a'), '<blink>a</blink>');
+assert.equal(bold('a'), '<b>a</b>');
+assert.equal(fixed('a'), '<tt>a</tt>');
+assert.equal(fontcolor('a', 'b'), '<font color="b">a</font>');
+assert.equal(fontsize('a', 'b'), '<font size="b">a</font>');
+assert.equal(italics('a'), '<i>a</i>');
+assert.equal(link('a', 'b'), '<a href="b">a</a>');
+assert.equal(small('a'), '<small>a</small>');
+assert.equal(strike('a'), '<strike>a</strike>');
+assert.equal(sub('a'), '<sub>a</sub>');
+assert.equal(sup('a'), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-1/result.js
+++ b/test/fixtures/es-string-html-methods/case-1/result.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-2/after.js
+++ b/test/fixtures/es-string-html-methods/case-2/after.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-2/before.js
+++ b/test/fixtures/es-string-html-methods/case-2/before.js
@@ -1,0 +1,16 @@
+require('es-string-html-methods/auto');
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-2/result.js
+++ b/test/fixtures/es-string-html-methods/case-2/result.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-3/after.js
+++ b/test/fixtures/es-string-html-methods/case-3/after.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-3/before.js
+++ b/test/fixtures/es-string-html-methods/case-3/before.js
@@ -1,0 +1,28 @@
+require('es-string-html-methods/anchor/auto');
+require('es-string-html-methods/big/auto');
+require('es-string-html-methods/blink/auto');
+require('es-string-html-methods/bold/auto');
+require('es-string-html-methods/fixed/auto');
+require('es-string-html-methods/fontcolor/auto');
+require('es-string-html-methods/fontsize/auto');
+require('es-string-html-methods/italics/auto');
+require('es-string-html-methods/link/auto');
+require('es-string-html-methods/small/auto');
+require('es-string-html-methods/strike/auto');
+require('es-string-html-methods/sub/auto');
+require('es-string-html-methods/sup/auto');
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');

--- a/test/fixtures/es-string-html-methods/case-3/result.js
+++ b/test/fixtures/es-string-html-methods/case-3/result.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+assert.equal('a'.anchor('b'), '<a name="b">a</a>');
+assert.equal('a'.big(), '<big>a</big>');
+assert.equal('a'.blink(), '<blink>a</blink>');
+assert.equal('a'.bold(), '<b>a</b>');
+assert.equal('a'.fixed(), '<tt>a</tt>');
+assert.equal('a'.fontcolor('b'), '<font color="b">a</font>');
+assert.equal('a'.fontsize('b'), '<font size="b">a</font>');
+assert.equal('a'.italics(), '<i>a</i>');
+assert.equal('a'.link('b'), '<a href="b">a</a>');
+assert.equal('a'.small(), '<small>a</small>');
+assert.equal('a'.strike(), '<strike>a</strike>');
+assert.equal('a'.sub(), '<sub>a</sub>');
+assert.equal('a'.sup(), '<sup>a</sup>');


### PR DESCRIPTION
Package: [`es-string-html-methods`](https://www.npmjs.com/package/es-string-html-methods)
Weekly Downloads: 654

Replace the following operations:
```javascript
[
  'anchor',
  'big',
  'blink',
  'bold',
  'fixed',
  'fontcolor',
  'fontsize',
  'italics',
  'link',
  'small',
  'strike',
  'sub',
  'sup',
]
```

I had to use `//@ts-ignore` two times. I tried to add types but since those are JS files the linter did not allow it. What is the best way to resolve this?