### PR TITLE
feat: add chalk codemod

### DIFF
--- a/codemods/chalk/index.js
+++ b/codemods/chalk/index.js
@@ -1,0 +1,177 @@
+import { ts } from '@ast-grep/napi';
+
+const picoNames = [
+	'isColorSupported',
+	'reset',
+	'bold',
+	'dim',
+	'italic',
+	'underline',
+	'inverse',
+	'hidden',
+	'strikethrough',
+	'black',
+	'red',
+	'green',
+	'yellow',
+	'blue',
+	'magenta',
+	'cyan',
+	'white',
+	'gray',
+	'bgBlack',
+	'bgRed',
+	'bgGreen',
+	'bgYellow',
+	'bgBlue',
+	'bgMagenta',
+	'bgCyan',
+	'bgWhite',
+];
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'chalk',
+		transform: ({ file }) => {
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const imports = root.findAll({
+				rule: {
+					pattern: {
+						context: "import $NAME from 'chalk'",
+						strictness: 'relaxed',
+					},
+				},
+			});
+			const requires = root.findAll({
+				rule: {
+					pattern: {
+						context: "require('chalk')",
+						strictness: 'relaxed',
+					},
+				},
+			});
+			let chalkName = 'chalk';
+			const edits = [];
+
+			for (const imp of imports) {
+				const source = imp.field('source');
+
+				if (!source) {
+					continue;
+				}
+
+				const quoteType = source.text().startsWith("'") ? "'" : '"';
+				const nameMatch = imp.getMatch('NAME');
+
+				if (nameMatch) {
+					chalkName = nameMatch.text();
+					edits.push(nameMatch.replace('pc'));
+				}
+
+				edits.push(source.replace(`${quoteType}picocolors${quoteType}`));
+			}
+
+			for (const req of requires) {
+				const args = req.field('arguments');
+				const firstArg = args?.child(1);
+				const quoteType = firstArg?.text().startsWith('"') ? '"' : "'";
+
+				edits.push(req.replace(`require(${quoteType}picocolors${quoteType})`));
+
+				const parent = req.parent();
+
+				if (parent && parent.kind() === 'variable_declarator') {
+					const name = parent.field('name');
+					if (name) {
+						chalkName = name.text();
+						edits.push(name.replace('pc'));
+					}
+				}
+			}
+
+			const chalkMethods = root.findAll({
+				utils: {
+					has_ident: {
+						any: [
+							{
+								has: {
+									kind: 'identifier',
+									regex: chalkName,
+								},
+							},
+							{
+								has: {
+									kind: 'member_expression',
+									matches: 'has_ident',
+								},
+							},
+						],
+					},
+				},
+				rule: {
+					kind: 'call_expression',
+					has: {
+						kind: 'member_expression',
+						matches: 'has_ident',
+					},
+				},
+			});
+
+			for (const method of chalkMethods) {
+				const fn = method.field('function');
+				const args = method.field('arguments');
+
+				if (!fn || !args) {
+					continue;
+				}
+
+				const fnParts = fn.text().split('.');
+				const extraNesting = ')'.repeat(fnParts.length - 2);
+
+				let newFn = '';
+
+				for (let i = 1; i < fnParts.length; i++) {
+					const part = fnParts[i];
+
+					if (!picoNames.includes(part)) {
+						throw new Error(
+							`Could not auto-fix code as picocolors does not support the ${part} export in source:\n\n${method.text()}`,
+						);
+					}
+
+					const last = i === fnParts.length - 1;
+					newFn += `pc.${part}${last ? '' : '('}`;
+				}
+
+				edits.push(fn.replace(newFn));
+
+				const argsChildren = args.children();
+				const argsFirstChild = argsChildren[0];
+				const argsLastChild = argsChildren[argsChildren.length - 1];
+
+				if (argsFirstChild.kind() !== '(') {
+					edits.push(argsFirstChild.replace(`(${argsFirstChild.text()}`));
+					edits.push(
+						argsLastChild.replace(`${argsLastChild.text()})${extraNesting}`),
+					);
+				} else {
+					edits.push(
+						argsLastChild.replace(`${argsLastChild.text()}${extraNesting}`),
+					);
+				}
+			}
+
+			return root.commitEdits(edits);
+		},
+	};
+}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ import arrayPrototypeUnshift from './codemods/array.prototype.unshift/index.js';
 import arrayPrototypeValues from './codemods/array.prototype.values/index.js';
 import arrayPrototypeWith from './codemods/array.prototype.with/index.js';
 import arraybufferPrototypeSlice from './codemods/arraybuffer.prototype.slice/index.js';
+import chalk from './codemods/chalk/index.js';
 import cloneRegexp from './codemods/clone-regexp/index.js';
 import concatMap from './codemods/concat-map/index.js';
 import dataViewBuffer from './codemods/data-view-buffer/index.js';
@@ -187,6 +188,7 @@ export const codemods = {
   "array.prototype.values": arrayPrototypeValues,
   "array.prototype.with": arrayPrototypeWith,
   "arraybuffer.prototype.slice": arraybufferPrototypeSlice,
+  "chalk": chalk,
   "clone-regexp": cloneRegexp,
   "concat-map": concatMap,
   "data-view-buffer": dataViewBuffer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ast-grep/napi": "^0.25.4",
         "jscodeshift": "^0.16.1"
       },
       "devDependencies": {
@@ -30,6 +31,160 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ast-grep/napi": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.25.4.tgz",
+      "integrity": "sha512-Ax6OBQehjv6Fw/qU3BlTvUmugK3BfMK7eV0aPrLAxJ3+0neQcE+p7QP42iiHsf1n/vG7npv7uUaBRfjzHH4hiQ==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ast-grep/napi-darwin-arm64": "0.25.4",
+        "@ast-grep/napi-darwin-x64": "0.25.4",
+        "@ast-grep/napi-linux-arm64-gnu": "0.25.4",
+        "@ast-grep/napi-linux-arm64-musl": "0.25.4",
+        "@ast-grep/napi-linux-x64-gnu": "0.25.4",
+        "@ast-grep/napi-linux-x64-musl": "0.25.4",
+        "@ast-grep/napi-win32-arm64-msvc": "0.25.4",
+        "@ast-grep/napi-win32-ia32-msvc": "0.25.4",
+        "@ast-grep/napi-win32-x64-msvc": "0.25.4"
+      }
+    },
+    "node_modules/@ast-grep/napi-darwin-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-qjqj0nARO1dJcsG2AQ2vaxtPV7je1A6SoYv3AG58/4mXdFg56hoVL4Op5DJpHNvg0e8rqkFJpJ7YIEFF2sQuAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-darwin-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-1JhmH7Nwpz90TtX2+4joN29kkn69j96guLZGueN1uE0q084po7DB8hJHmn37o3eL1WCdeh1cptGGoHCfBnYBWw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-arm64-gnu": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.25.4.tgz",
+      "integrity": "sha512-0oC/czHjMJ3mtu5+o374xf4aOmr4/0xyW4JKyjSSJKlWhME/LZH/O4BOPPBi/xAOsqmb+t0J/lYEO4MoJOKeaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-arm64-musl": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.25.4.tgz",
+      "integrity": "sha512-KGyHxoxXBcPrCezoGloFrkzFrQIEco5SicvK7hwuhOWuR521LygFtcR9QOq3tjOaLDmznLuM/M/RDYwTqQIPeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-x64-gnu": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.25.4.tgz",
+      "integrity": "sha512-ttBnrapPkJQPjgE6dCjOTWkpBjKz9y2Sc/ZiOB1B5xEQWCy0Oh35W8xkBdRjlfiU9RvVBCq5LrR5VX6nvKPZlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-x64-musl": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.25.4.tgz",
+      "integrity": "sha512-NwMPsne+xikZCbPDoXNdwYPJQ8+1mMPHXbrJvBUgil/xjwZFTy/Z7KKEHFJ64lOeQixswz2KNLZgkE2CtxvRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-arm64-msvc": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.25.4.tgz",
+      "integrity": "sha512-FOCxrPFWR7WgfpCz9vmE1SJGM2RB26ZaB3aRvnmopBkQVvZTZ/CyjG9Eee2zzu659OA4SoDO4eQ0m/VdL3LXUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-ia32-msvc": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.25.4.tgz",
+      "integrity": "sha512-UEnMzBnGA900BjdgVek9pnzsxodykzvXaVkUvmyLDHfu9Ql/lkjvgPlRi57pdwTsknkvHFAdtvvsrVA9qC0P1Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-x64-msvc": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.25.4.tgz",
+      "integrity": "sha512-itYPveFAbV19XyqaHIVO78N4doPMqGjbnTFjZD2fvCHXzUujxqlCXEt45+tNq9iXtn38e4wZB21ew0N2bX6IEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@ast-grep/napi": "^0.25.4",
     "jscodeshift": "^0.16.1"
   },
   "files": [

--- a/test/fixtures/chalk/cjs/after.js
+++ b/test/fixtures/chalk/cjs/after.js
@@ -1,0 +1,11 @@
+const pc = require('picocolors');
+
+pc.red();
+pc.red('im red');
+pc.red(pc.bold('im red and bold'));
+pc.red(`im a red template`);
+pc.red(pc.bold(`im a red and bold template`));
+pc.red(`im an interpolated ${val} template`);
+pc.red(`i contain ${pc.bold('sub chalks')}`);
+pc.red(`i contain ${pc.bold(`sub templates`)}`);
+pc.red(`i contain chained ${pc.blue(pc.bold('sub chalks'))}`);

--- a/test/fixtures/chalk/cjs/before.js
+++ b/test/fixtures/chalk/cjs/before.js
@@ -1,0 +1,11 @@
+const ch = require('chalk');
+
+ch.red();
+ch.red('im red');
+ch.red.bold('im red and bold');
+ch.red`im a red template`;
+ch.red.bold`im a red and bold template`;
+ch.red`im an interpolated ${val} template`;
+ch.red`i contain ${ch.bold('sub chalks')}`;
+ch.red`i contain ${ch.bold`sub templates`}`;
+ch.red`i contain chained ${ch.blue.bold('sub chalks')}`;

--- a/test/fixtures/chalk/cjs/result.js
+++ b/test/fixtures/chalk/cjs/result.js
@@ -1,0 +1,11 @@
+const pc = require('picocolors');
+
+pc.red();
+pc.red('im red');
+pc.red(pc.bold('im red and bold'));
+pc.red(`im a red template`);
+pc.red(pc.bold(`im a red and bold template`));
+pc.red(`im an interpolated ${val} template`);
+pc.red(`i contain ${pc.bold('sub chalks')}`);
+pc.red(`i contain ${pc.bold(`sub templates`)}`);
+pc.red(`i contain chained ${pc.blue(pc.bold('sub chalks'))}`);

--- a/test/fixtures/chalk/esm/after.js
+++ b/test/fixtures/chalk/esm/after.js
@@ -1,0 +1,11 @@
+import pc from 'picocolors';
+
+pc.red();
+pc.red('im red');
+pc.red(pc.bold('im red and bold'));
+pc.red(`im a red template`);
+pc.red(pc.bold(`im a red and bold template`));
+pc.red(`im an interpolated ${val} template`);
+pc.red(`i contain ${pc.bold('sub chalks')}`);
+pc.red(`i contain ${pc.bold(`sub templates`)}`);
+pc.red(`i contain chained ${pc.blue(pc.bold('sub chalks'))}`);

--- a/test/fixtures/chalk/esm/before.js
+++ b/test/fixtures/chalk/esm/before.js
@@ -1,0 +1,11 @@
+import ch from 'chalk';
+
+ch.red();
+ch.red('im red');
+ch.red.bold('im red and bold');
+ch.red`im a red template`;
+ch.red.bold`im a red and bold template`;
+ch.red`im an interpolated ${val} template`;
+ch.red`i contain ${ch.bold('sub chalks')}`;
+ch.red`i contain ${ch.bold`sub templates`}`;
+ch.red`i contain chained ${ch.blue.bold('sub chalks')}`;

--- a/test/fixtures/chalk/esm/result.js
+++ b/test/fixtures/chalk/esm/result.js
@@ -1,0 +1,11 @@
+import pc from 'picocolors';
+
+pc.red();
+pc.red('im red');
+pc.red(pc.bold('im red and bold'));
+pc.red(`im a red template`);
+pc.red(pc.bold(`im a red and bold template`));
+pc.red(`im an interpolated ${val} template`);
+pc.red(`i contain ${pc.bold('sub chalks')}`);
+pc.red(`i contain ${pc.bold(`sub templates`)}`);
+pc.red(`i contain chained ${pc.blue(pc.bold('sub chalks'))}`);


### PR DESCRIPTION
Adds a codemod for moving from `chalk` to `picocolors`.

This will throw if exports are encountered which picocolors doesn't provide. For example, as of writing this, picocolors doesn't support bright colours (but soon will). That means `chalk.redBright` will throw since picocolors has no `redBright` export.

These patterns are supported:

```ts

// Before
chalk.red.bold(str);
// After
pc.red(pc.bold(str));

// Before
chalk.red`i am red`;
// After
pc.red(`i am red`);

// Before
chalk.red`i am red and ${chalk.bold('bold')}!`;
// After
pc.red(`i am red and ${pc.bold('bold')}!`);
```

Some patterns will not be detected. For example:

```ts
// Not detected since it isn't a call expression
chalk.red;

// Similarly not detected
const red = chalk.red;
red(str);
```