### PR TITLE
add deep-equal codemod

### DIFF
--- a/codemods/deep-equal/index.js
+++ b/codemods/deep-equal/index.js
@@ -1,0 +1,29 @@
+import jscodeshift from 'jscodeshift';
+import { replaceImport } from '../replaceImport.js';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'deep-equal',
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			const didReplacement = replaceImport(
+				j,
+				root,
+				{ moduleName: 'deep-equal', importName: 'default', cjsNamespace: true },
+				{ moduleName: 'dequal', importName: 'dequal', cjsNamespace: false },
+			);
+
+			return didReplacement ? root.toSource() : file.source;
+		},
+	};
+}

--- a/codemods/replaceImport.js
+++ b/codemods/replaceImport.js
@@ -1,0 +1,147 @@
+/**
+ * @typedef {Object} Module
+ * @property {String} moduleName
+ * @property {String} importName
+ * @property {boolean?} cjsNamespace
+ */
+
+/**
+ * Replaces an import statement from one module to another. Handles esm different
+ * variations of esm and cjs imports, as well as code references to the imports.
+ *
+ * @param {import('jscodeshift')} j
+ * @param {import('jscodeshift').Collection<any>} root
+ * @param {Module} importModule
+ * @param {Module} replacementModule
+ */
+export function replaceImport(j, root, importModule, replacementModule) {
+	const createError = (/** @type {string} */ msg) =>
+		new Error(`Could not replace ${importModule.moduleName}: ${msg}`);
+	/** @type {string | undefined} */
+	let bindingName;
+	const importDeclarations = root.find(j.ImportDeclaration, {
+		source: { value: importModule.moduleName },
+	});
+
+	const requireDeclarations = root.find(j.VariableDeclarator, {
+		init: {
+			callee: { name: 'require' },
+			arguments: [{ value: importModule.moduleName }],
+		},
+	});
+
+	if (importDeclarations.size() + requireDeclarations.size() > 1) {
+		throw createError('Multiple import statements are not yet supported');
+	}
+
+	importDeclarations.forEach((path) => {
+		if (path.value.source.value === importModule.moduleName) {
+			const specifiers = path.value.specifiers ?? [];
+			if (specifiers.length > 1) {
+				throw new Error(
+					`Error while replacing \`${importModule.moduleName}\`, multiple specifiers not supported`,
+				);
+			}
+
+			const specifier = specifiers[0];
+			if (specifier.type === 'ImportSpecifier') {
+				if (
+					importModule.importName !== 'default' &&
+					importModule.importName === specifier.imported.name
+				) {
+					bindingName = specifier.local?.name ?? specifier.imported.name;
+				}
+			} else if (
+				specifier.type === 'ImportDefaultSpecifier' &&
+				importModule.importName === 'default'
+			) {
+				bindingName = specifier.local?.name;
+			} else if (specifier.type === 'ImportNamespaceSpecifier') {
+				const localName = specifier.local?.name;
+				if (!localName) {
+					throw createError('Namespace specifier does not have a local name.');
+				}
+				// look up references to the namespace
+				root.findVariableDeclarators().forEach((declarator) => {
+					const { id, init } = declarator.node;
+					if (id.type === 'Identifier' && init?.type === 'MemberExpression') {
+						// case: const foo = bar.foo;
+						const { object, property } = init;
+						if (
+							object.type === 'Identifier' &&
+							object.name === localName &&
+							property.type === 'Identifier' &&
+							property.name === importModule.importName
+						) {
+							bindingName = id.name;
+						}
+					} else if (
+						id.type === 'ObjectPattern' &&
+						init?.type === 'Identifier'
+					) {
+						// case: const { foo } = bar; or const { foo: x } = bar;
+						if (init.name === localName) {
+							const prop = id.properties.find(
+								(prop) =>
+									prop.type === 'Property' &&
+									prop.key.type === 'Identifier' &&
+									prop.key.name === importModule.importName,
+							);
+							if (
+								prop?.type === 'Property' &&
+								prop.value.type === 'Identifier'
+							) {
+								bindingName = prop.value.name;
+							}
+						}
+					}
+
+					// remove the namespace lookup, since we are rewriting it into a named or default import
+					if (bindingName) {
+						declarator.prune();
+					}
+				});
+			}
+
+			if (bindingName) {
+				path.value.source = j.literal(replacementModule.moduleName);
+				const specifierType =
+					replacementModule.importName === 'default'
+						? j.importDefaultSpecifier
+						: j.importSpecifier;
+				path.value.specifiers = [
+					specifierType(j.identifier(replacementModule.moduleName)),
+				];
+			}
+		}
+	});
+
+	requireDeclarations.forEach((path) => {
+		if (path.value.id.type === 'Identifier') {
+			bindingName = path.value.id.name;
+			path.value.id = j.objectPattern.from({
+				properties: [
+					j.property.from({
+						key: j.identifier(replacementModule.moduleName),
+						value: j.identifier(replacementModule.importName),
+						shorthand: true,
+						kind: 'init',
+					}),
+				],
+			});
+		}
+
+		if (path.value.init?.type === 'CallExpression') {
+			path.value.init.arguments[0] = j.literal(replacementModule.moduleName);
+		}
+	});
+
+	if (bindingName) {
+		const identifiers = root.find(j.Identifier, { name: bindingName });
+		identifiers.forEach((identifier) => {
+			identifier.replace(j.identifier(replacementModule.importName));
+		});
+	}
+
+	return !!bindingName;
+}

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ import dataViewBuffer from './codemods/data-view-buffer/index.js';
 import dataViewByteLength from './codemods/data-view-byte-length/index.js';
 import dataViewByteOffset from './codemods/data-view-byte-offset/index.js';
 import date from './codemods/date/index.js';
+import deepEqual from './codemods/deep-equal/index.js';
 import defineProperties from './codemods/define-properties/index.js';
 import errorCause from './codemods/error-cause/index.js';
 import esAggregateError from './codemods/es-aggregate-error/index.js';
@@ -193,6 +194,7 @@ export const codemods = {
   "data-view-byte-length": dataViewByteLength,
   "data-view-byte-offset": dataViewByteOffset,
   "date": date,
+  "deep-equal": deepEqual,
   "define-properties": defineProperties,
   "error-cause": errorCause,
   "es-aggregate-error": esAggregateError,

--- a/test/fixtures/deep-equal/cjs/after.js
+++ b/test/fixtures/deep-equal/cjs/after.js
@@ -1,0 +1,21 @@
+const {
+  dequal
+} = require("dequal");
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/cjs/before.js
+++ b/test/fixtures/deep-equal/cjs/before.js
@@ -1,0 +1,19 @@
+const deepEqual = require('deep-equal');
+
+deepEqual("a", "a");
+
+deepEqual({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return deepEqual(["a"], ["b"]);
+  }
+}
+
+{
+  deepEqual("x", "y");
+}
+
+function x() {
+  deepEqual("x", "x");
+}

--- a/test/fixtures/deep-equal/cjs/result.js
+++ b/test/fixtures/deep-equal/cjs/result.js
@@ -1,0 +1,21 @@
+const {
+  dequal
+} = require("dequal");
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-default/after.js
+++ b/test/fixtures/deep-equal/esm-default/after.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-default/before.js
+++ b/test/fixtures/deep-equal/esm-default/before.js
@@ -1,0 +1,19 @@
+import deepEqual from "deep-equal";
+
+deepEqual("a", "a");
+
+deepEqual({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return deepEqual(["a"], ["b"]);
+  }
+}
+
+{
+  deepEqual("x", "y");
+}
+
+function x() {
+  deepEqual("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-default/result.js
+++ b/test/fixtures/deep-equal/esm-default/result.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-assignment/after.js
+++ b/test/fixtures/deep-equal/esm-namespace-assignment/after.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-assignment/before.js
+++ b/test/fixtures/deep-equal/esm-namespace-assignment/before.js
@@ -1,0 +1,21 @@
+import * as deepEqualModule from "deep-equal";
+
+const myDeepEqual = deepEqualModule.default;
+
+myDeepEqual("a", "a");
+
+myDeepEqual({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return myDeepEqual(["a"], ["b"]);
+  }
+}
+
+{
+  myDeepEqual("x", "y");
+}
+
+function x() {
+  myDeepEqual("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-assignment/result.js
+++ b/test/fixtures/deep-equal/esm-namespace-assignment/result.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-destructure/after.js
+++ b/test/fixtures/deep-equal/esm-namespace-destructure/after.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-destructure/before.js
+++ b/test/fixtures/deep-equal/esm-namespace-destructure/before.js
@@ -1,0 +1,21 @@
+import * as deepEqualModule from "deep-equal";
+
+const { default: myDeepEqual } = deepEqualModule;
+
+myDeepEqual("a", "a");
+
+myDeepEqual({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return myDeepEqual(["a"], ["b"]);
+  }
+}
+
+{
+  myDeepEqual("x", "y");
+}
+
+function x() {
+  myDeepEqual("x", "x");
+}

--- a/test/fixtures/deep-equal/esm-namespace-destructure/result.js
+++ b/test/fixtures/deep-equal/esm-namespace-destructure/result.js
@@ -1,0 +1,19 @@
+import { dequal } from "dequal";
+
+dequal("a", "a");
+
+dequal({ a: "a", b: "b" }, { a: "a", b: "b" });
+
+class Foo {
+  bar() {
+    return dequal(["a"], ["b"]);
+  }
+}
+
+{
+  dequal("x", "y");
+}
+
+function x() {
+  dequal("x", "x");
+}


### PR DESCRIPTION
This adds a codemod for `deep-equal`. 

I also added a shared util for a generic `replaceImports` function, which can replace a module import as well as all of it's usages. This util should handle different ways of importing modules, as well as reassigning/destructuring imports outside of the initial import statement. For example:

```js
import * as module from 'deep-equal';

const foo = module.default;

foo('a', 'b');
```

This way future codemods can be implemented very easily based on this function, handling all the edge cases.

Right now the function doesn't handle scoping at all, so this will break:

```js
import deepEqual from 'deep-equal';

function maybeDeepEqual(deepEqual) {
  deepEqual('a', 'b');
}

maybeDeepEqual(null);
```

I've implemented scope handling / binding tracking with babel transforms, but I couldn't get it working within jscodeshift yet. Something to add later, but for these kinds of codemods this may not be super common.