### PR TITLE
fix: remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test:watch": "node --test --watch test/codemod.test.js",
     "format": "biome format --write **/*",
     "lint:types": "tsc",
-    "postinstall": "npm run which",
     "which": "node scripts/which.js",
     "prepublishOnly": "node scripts/generate-index.js"
   },


### PR DESCRIPTION
Removes the postinstall script as it is currently failing and causing installs to fail.