### PR TITLE
fix: consider import removal to be dirty

### DIFF
--- a/test/fixtures/array-every/imports-only/after.js
+++ b/test/fixtures/array-every/imports-only/after.js
@@ -1,0 +1,1 @@
+export const n = 303;

--- a/test/fixtures/array-every/imports-only/before.js
+++ b/test/fixtures/array-every/imports-only/before.js
@@ -1,0 +1,3 @@
+const every = require("array-every");
+
+export const n = 303;

--- a/test/fixtures/array-every/imports-only/result.js
+++ b/test/fixtures/array-every/imports-only/result.js
@@ -1,0 +1,1 @@
+export const n = 303;


### PR DESCRIPTION
When using the `transformArrayMethod` helper, we currently only consider the change to be dirty if call expressions we mutated.

This means imports of these modules will not be removed unless there are also associated call expressions.

This fix simply considers removal of the import to be a dirty change.

Fixes #88