### PR TITLE
feat: add iterate-value

### DIFF
--- a/codemods/iterate-value/index.js
+++ b/codemods/iterate-value/index.js
@@ -1,0 +1,125 @@
+import { ts } from '@ast-grep/napi';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'iterate-value',
+		transform: ({ file }) => {
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const imports = root.findAll({
+				rule: {
+					any: [
+						{
+							pattern: {
+								context: "import $NAME from 'iterate-value'",
+								strictness: 'relaxed',
+							},
+						},
+						{
+							pattern: {
+								context: "const $NAME = require('iterate-value')",
+								strictness: 'relaxed',
+							},
+						},
+					],
+				},
+			});
+
+			const edits = [];
+			/** @type {string|null} */
+			let importedName = null;
+
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			for (const node of imports) {
+				if (!importedName) {
+					const name = node.getMatch('NAME')?.text();
+
+					if (name) {
+						importedName = name;
+					}
+				}
+
+				edits.push(node.replace(''));
+			}
+
+			const calls = root.findAll({
+				rule: {
+					any: [
+						{
+							pattern: `${importedName}($ITERABLE)`,
+						},
+						{
+							pattern: `${importedName}($ITERABLE, $CALLBACK)`,
+						},
+					],
+				},
+			});
+
+			for (const node of calls) {
+				const iter = node.getMatch('ITERABLE');
+				const callback = node.getMatch('CALLBACK');
+
+				if (!iter) {
+					continue;
+				}
+
+				if (!callback) {
+					edits.push(node.replace(`Array.from(${iter.text()})`));
+				} else {
+					const callbackKind = callback.kind();
+					const callbackBody = callback.field('body');
+
+					if (
+						(callbackKind === 'arrow_function' ||
+							callbackKind === 'function_expression') &&
+						callbackBody
+					) {
+						const params = callback.field('parameters');
+						let valueName = '_value';
+
+						if (params) {
+							for (const param of params.children()) {
+								const paramKind = param.kind();
+
+								if (paramKind === 'required_parameter') {
+									valueName = param.text();
+									break;
+								}
+							}
+						}
+
+						edits.push(
+							node.replace(
+								`for (const ${valueName} of (${iter.text()})) ${callbackBody.text()}`,
+							),
+						);
+					} else {
+						edits.push(
+							node.replace(
+								`for (const value of (${iter.text()})) { ${callback.text()}(value); }`,
+							),
+						);
+					}
+				}
+			}
+
+			if (edits.length === 0) {
+				return file.source;
+			}
+
+			return root.commitEdits(edits);
+		},
+	};
+}

--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ import isString from './codemods/is-string/index.js';
 import isTravis from './codemods/is-travis/index.js';
 import isWhitespace from './codemods/is-whitespace/index.js';
 import isWindows from './codemods/is-windows/index.js';
+import iterateValue from './codemods/iterate-value/index.js';
 import lastIndexOf from './codemods/last-index-of/index.js';
 import leftPad from './codemods/left-pad/index.js';
 import mathAcosh from './codemods/math.acosh/index.js';
@@ -250,6 +251,7 @@ export const codemods = {
   "is-travis": isTravis,
   "is-whitespace": isWhitespace,
   "is-windows": isWindows,
+  "iterate-value": iterateValue,
   "last-index-of": lastIndexOf,
   "left-pad": leftPad,
   "math.acosh": mathAcosh,

--- a/test/fixtures/iterate-value/simple-cjs/after.js
+++ b/test/fixtures/iterate-value/simple-cjs/after.js
@@ -1,0 +1,34 @@
+
+
+// string, no callback
+const collection0 = Array.from('foo');
+
+// string, callback
+for (const chr of ('foo')) {
+  console.log(chr);
+};
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+for (const value of ('foo')) { callback0(value); };
+
+// array, no callback
+const collection1 = Array.from([3, 0, 3]);
+
+// array, callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, function callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, no value in callback
+for (const _value of ([8, 0, 8])) {
+  console.log('bleep bloop');
+};
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/test/fixtures/iterate-value/simple-cjs/before.js
+++ b/test/fixtures/iterate-value/simple-cjs/before.js
@@ -1,0 +1,34 @@
+const iterate = require('iterate-value');
+
+// string, no callback
+const collection0 = iterate('foo');
+
+// string, callback
+iterate('foo', (chr) => {
+  console.log(chr);
+});
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+iterate('foo', callback0);
+
+// array, no callback
+const collection1 = iterate([3, 0, 3]);
+
+// array, callback
+iterate([3, 0, 3], (num) => {
+  console.log(num);
+});
+
+// array, function callback
+iterate([3, 0, 3], function (num) {
+  console.log(num);
+});
+
+// array, no value in callback
+iterate([8, 0, 8], () => {
+  console.log('bleep bloop');
+});
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/test/fixtures/iterate-value/simple-cjs/result.js
+++ b/test/fixtures/iterate-value/simple-cjs/result.js
@@ -1,0 +1,34 @@
+
+
+// string, no callback
+const collection0 = Array.from('foo');
+
+// string, callback
+for (const chr of ('foo')) {
+  console.log(chr);
+};
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+for (const value of ('foo')) { callback0(value); };
+
+// array, no callback
+const collection1 = Array.from([3, 0, 3]);
+
+// array, callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, function callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, no value in callback
+for (const _value of ([8, 0, 8])) {
+  console.log('bleep bloop');
+};
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/test/fixtures/iterate-value/simple/after.js
+++ b/test/fixtures/iterate-value/simple/after.js
@@ -1,0 +1,34 @@
+
+
+// string, no callback
+const collection0 = Array.from('foo');
+
+// string, callback
+for (const chr of ('foo')) {
+  console.log(chr);
+};
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+for (const value of ('foo')) { callback0(value); };
+
+// array, no callback
+const collection1 = Array.from([3, 0, 3]);
+
+// array, callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, function callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, no value in callback
+for (const _value of ([8, 0, 8])) {
+  console.log('bleep bloop');
+};
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/test/fixtures/iterate-value/simple/before.js
+++ b/test/fixtures/iterate-value/simple/before.js
@@ -1,0 +1,34 @@
+import iterate from 'iterate-value';
+
+// string, no callback
+const collection0 = iterate('foo');
+
+// string, callback
+iterate('foo', (chr) => {
+  console.log(chr);
+});
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+iterate('foo', callback0);
+
+// array, no callback
+const collection1 = iterate([3, 0, 3]);
+
+// array, callback
+iterate([3, 0, 3], (num) => {
+  console.log(num);
+});
+
+// array, function callback
+iterate([3, 0, 3], function (num) {
+  console.log(num);
+});
+
+// array, no value in callback
+iterate([8, 0, 8], () => {
+  console.log('bleep bloop');
+});
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/test/fixtures/iterate-value/simple/result.js
+++ b/test/fixtures/iterate-value/simple/result.js
@@ -1,0 +1,34 @@
+
+
+// string, no callback
+const collection0 = Array.from('foo');
+
+// string, callback
+for (const chr of ('foo')) {
+  console.log(chr);
+};
+
+// string, callback ref
+const callback0 = (chr) => console.log(chr);
+for (const value of ('foo')) { callback0(value); };
+
+// array, no callback
+const collection1 = Array.from([3, 0, 3]);
+
+// array, callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, function callback
+for (const num of ([3, 0, 3])) {
+  console.log(num);
+};
+
+// array, no value in callback
+for (const _value of ([8, 0, 8])) {
+  console.log('bleep bloop');
+};
+
+// ignored because it has invalid usage
+iterate([8, 0, 8], (num) => {}, 'unexpected-third-arg');

--- a/types/codemods/iterate-value/index.d.ts
+++ b/types/codemods/iterate-value/index.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function _default(options?: import("../../types.js").CodemodOptions | undefined): Codemod;
+export type Codemod = import("../../types.js").Codemod;
+export type CodemodOptions = import("../../types.js").CodemodOptions;


### PR DESCRIPTION
Adds a codemod for `iterate-value`.

This handles the following cases:

```ts
// with an inline arrow function (BEFORE)
iterate([], (v) => {});
// with an inline arrow function (AFTER)
for (const v of ([])) {};

// with a referenced function (BEFORE)
const fn = (v) => {};
iterate([], fn);
// with a referenced function (AFTER)
for (const value of ([])) { fn(value); };

// without a callback (BEFORE)
iterate([1, 1, 1]);
// without a callback (AFTER)
Array.from([1, 1, 1]);
```

the semi colon gets left behind on the `for` loops which feels awkward. however, i think people should be expected to run a formatter after using this codemod anyway since we're adding blocks of code rather than simple changes.