### PR TITLE
fix: always import picocolors as namespace

### DIFF
--- a/codemods/chalk/index.js
+++ b/codemods/chalk/index.js
@@ -74,8 +74,21 @@ export default function (options) {
 				const nameMatch = imp.getMatch('NAME');
 
 				if (nameMatch) {
-					chalkName = nameMatch.text();
-					edits.push(nameMatch.replace('pc'));
+					const namespaceImport = nameMatch.find({
+						rule: {
+							kind: 'identifier',
+							inside: {
+								kind: 'namespace_import',
+							},
+						},
+					});
+
+					if (namespaceImport) {
+						chalkName = namespaceImport.text();
+					} else {
+						chalkName = nameMatch.text();
+					}
+					edits.push(nameMatch.replace('* as pc'));
 				}
 
 				edits.push(source.replace(`${quoteType}picocolors${quoteType}`));

--- a/test/fixtures/chalk/esm/after.js
+++ b/test/fixtures/chalk/esm/after.js
@@ -1,4 +1,4 @@
-import pc from 'picocolors';
+import * as pc from 'picocolors';
 
 pc.red();
 pc.red('im red');

--- a/test/fixtures/chalk/esm/result.js
+++ b/test/fixtures/chalk/esm/result.js
@@ -1,4 +1,4 @@
-import pc from 'picocolors';
+import * as pc from 'picocolors';
 
 pc.red();
 pc.red('im red');


### PR DESCRIPTION
Currently we incorrectly import `picocolors` as if there's a default export:

```ts
import pc from 'picocolors';
```

This is incorrect since `picocolors` exports individual functions. So this fix will update it to the following:

```ts
import * as pc from 'picocolors';
```