### PR TITLE
feat(codemod): add buffer-equals codemod

### DIFF
--- a/codemods/buffer-equals/index.js
+++ b/codemods/buffer-equals/index.js
@@ -1,0 +1,65 @@
+import jscodeshift from 'jscodeshift';
+import {
+	DEFAULT_IMPORT,
+	getImportIdentifierMap,
+	removeImport,
+} from '../shared.js';
+
+const MODULE_NAME = 'buffer-equals';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ */
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: MODULE_NAME,
+		transform: ({ file }) => {
+			const j = jscodeshift;
+			const root = j(file.source);
+			let transformCount = 0;
+			let dirtyFlag = false;
+
+			const map = getImportIdentifierMap(MODULE_NAME, root, j);
+
+			const identifier = map[DEFAULT_IMPORT];
+
+			const callExpressions = root.find(j.CallExpression, {
+				callee: {
+					name: identifier,
+				},
+			});
+
+			if (!callExpressions.length) {
+				removeImport(MODULE_NAME, root, j);
+				return root.toSource(options);
+			}
+
+			callExpressions.forEach((p) => {
+				const args = p.node.arguments;
+				if (args.length === 2 && args[0].type !== 'SpreadElement') {
+					const [firstArg, secondArg] = args;
+					j(p).replaceWith(
+						j.callExpression(
+							j.memberExpression(firstArg, j.identifier('equals')),
+							[secondArg],
+						),
+					);
+					dirtyFlag = true;
+					transformCount++;
+				}
+			});
+
+			if (transformCount === callExpressions.length) {
+				removeImport(MODULE_NAME, root, j);
+			}
+
+			return dirtyFlag ? root.toSource(options) : file.source;
+		},
+	};
+}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ import arrayPrototypeUnshift from './codemods/array.prototype.unshift/index.js';
 import arrayPrototypeValues from './codemods/array.prototype.values/index.js';
 import arrayPrototypeWith from './codemods/array.prototype.with/index.js';
 import arraybufferPrototypeSlice from './codemods/arraybuffer.prototype.slice/index.js';
+import bufferEquals from './codemods/buffer-equals/index.js';
 import chalk from './codemods/chalk/index.js';
 import cloneRegexp from './codemods/clone-regexp/index.js';
 import concatMap from './codemods/concat-map/index.js';
@@ -203,6 +204,7 @@ export const codemods = {
   "array.prototype.values": arrayPrototypeValues,
   "array.prototype.with": arrayPrototypeWith,
   "arraybuffer.prototype.slice": arraybufferPrototypeSlice,
+  "buffer-equals": bufferEquals,
   "chalk": chalk,
   "clone-regexp": cloneRegexp,
   "concat-map": concatMap,

--- a/test/fixtures/buffer-equals/case-1/after.js
+++ b/test/fixtures/buffer-equals/case-1/after.js
@@ -1,0 +1,6 @@
+const { Buffer } = require('node:buffer');
+
+const buf1 = Buffer.from('abc');
+
+const arr = Buffer.from([253, 254, 255]).equals(Buffer.from([253, 254, 255]));
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-1/before.js
+++ b/test/fixtures/buffer-equals/case-1/before.js
@@ -1,0 +1,7 @@
+const { Buffer } = require('node:buffer');
+const bufferEqual = require('buffer-equals');
+
+const buf1 = Buffer.from('abc');
+
+const arr = bufferEqual(Buffer.from([253, 254, 255]), Buffer.from([253, 254, 255]));
+const str = bufferEqual(buf1, Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-1/result.js
+++ b/test/fixtures/buffer-equals/case-1/result.js
@@ -1,0 +1,6 @@
+const { Buffer } = require('node:buffer');
+
+const buf1 = Buffer.from('abc');
+
+const arr = Buffer.from([253, 254, 255]).equals(Buffer.from([253, 254, 255]));
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-2/after.js
+++ b/test/fixtures/buffer-equals/case-2/after.js
@@ -1,0 +1,8 @@
+const { Buffer } = require('node:buffer');
+const bufferEqual = require('buffer-equals');
+
+const buf1 = Buffer.from('abc');
+const buffs = [Buffer.from([253, 254, 255]), Buffer.from([253, 254, 255])]
+
+const arr = bufferEqual(...buffs);
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-2/before.js
+++ b/test/fixtures/buffer-equals/case-2/before.js
@@ -1,0 +1,8 @@
+const { Buffer } = require('node:buffer');
+const bufferEqual = require('buffer-equals');
+
+const buf1 = Buffer.from('abc');
+const buffs = [Buffer.from([253, 254, 255]), Buffer.from([253, 254, 255])]
+
+const arr = bufferEqual(...buffs);
+const str = bufferEqual(buf1, Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-2/result.js
+++ b/test/fixtures/buffer-equals/case-2/result.js
@@ -1,0 +1,8 @@
+const { Buffer } = require('node:buffer');
+const bufferEqual = require('buffer-equals');
+
+const buf1 = Buffer.from('abc');
+const buffs = [Buffer.from([253, 254, 255]), Buffer.from([253, 254, 255])]
+
+const arr = bufferEqual(...buffs);
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-3/after.js
+++ b/test/fixtures/buffer-equals/case-3/after.js
@@ -1,0 +1,5 @@
+const { Buffer } = require('node:buffer');
+
+const buf1 = Buffer.from('abc');
+
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-3/before.js
+++ b/test/fixtures/buffer-equals/case-3/before.js
@@ -1,0 +1,6 @@
+const { Buffer } = require('node:buffer');
+const bufferEqual = require('buffer-equals');
+
+const buf1 = Buffer.from('abc');
+
+const str = buf1.equals(Buffer.from('def'));

--- a/test/fixtures/buffer-equals/case-3/result.js
+++ b/test/fixtures/buffer-equals/case-3/result.js
@@ -1,0 +1,5 @@
+const { Buffer } = require('node:buffer');
+
+const buf1 = Buffer.from('abc');
+
+const str = buf1.equals(Buffer.from('def'));


### PR DESCRIPTION
Codemod for replacing most common usages of `buffer-equals` and doesn't remove the import if it didn't cover all the usages.

Aligning with https://github.com/es-tooling/module-replacements/issues/170 and https://github.com/es-tooling/module-replacements/issues/171

Related to #96 