### PR TITLE
fix(qs): always replace with namespaced import

### DIFF
--- a/codemods/qs/index.js
+++ b/codemods/qs/index.js
@@ -165,8 +165,20 @@ export default function (options) {
 				const nameMatch = imp.getMatch('NAME');
 
 				if (nameMatch) {
-					importName = nameMatch.text();
-					edits.push(nameMatch.replace('pq'));
+					const namespaceImport = nameMatch.find({
+						rule: {
+							kind: 'identifier',
+							inside: {
+								kind: 'namespace_import',
+							},
+						},
+					});
+					if (namespaceImport) {
+						importName = namespaceImport.text();
+					} else {
+						importName = nameMatch.text();
+					}
+					edits.push(nameMatch.replace('* as pq'));
 				}
 
 				edits.push(source.replace(`${quoteType}picoquery${quoteType}`));

--- a/test/fixtures/qs/basic/after.js
+++ b/test/fixtures/qs/basic/after.js
@@ -1,4 +1,4 @@
-import pq from 'picoquery';
+import * as pq from 'picoquery';
 
 const obj = {foo: 'bar'};
 const query = 'foo=bar';

--- a/test/fixtures/qs/basic/result.js
+++ b/test/fixtures/qs/basic/result.js
@@ -1,4 +1,4 @@
-import pq from 'picoquery';
+import * as pq from 'picoquery';
 
 const obj = {foo: 'bar'};
 const query = 'foo=bar';


### PR DESCRIPTION
Basically the same fix as in https://github.com/es-tooling/module-replacements-codemods/pull/95
(I copy pasta)

My build crashed because `pq` doesnt have a default export

PS: I am not sure if the require branch of the codemod also needs the same adaptation. I didnt see it in #95
