### PR TITLE
feat: add rimraf codemod

### DIFF
--- a/codemods/rimraf/index.js
+++ b/codemods/rimraf/index.js
@@ -1,0 +1,266 @@
+import { ts } from '@ast-grep/napi';
+
+/**
+ * @typedef {import('../../types.js').Codemod} Codemod
+ * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
+ * @typedef {import('@ast-grep/napi').Edit} Edit
+ */
+
+const defaultOptions = `{recursive: true, force: true}`;
+/**
+ * @param {boolean} useRequire
+ * @param {string} quoteType
+ * @param {string[]} names
+ * @param {string} source
+ * @returns {string}
+ */
+const computeImport = (useRequire, quoteType, names, source) => {
+	if (useRequire) {
+		return `const {${names.join(', ')}} = require(${quoteType}${source}${quoteType});`;
+	}
+	return `import {${names.join(', ')}} from ${quoteType}${source}${quoteType};`;
+};
+
+/**
+ * @param {CodemodOptions} [options]
+ * @returns {Codemod}
+ */
+export default function (options) {
+	return {
+		name: 'rimraf',
+		transform: ({ file }) => {
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const imports = root.findAll({
+				rule: {
+					any: [
+						{
+							pattern: {
+								context: "import * as $NAME from 'rimraf'",
+								strictness: 'relaxed',
+							},
+						},
+						{
+							pattern: {
+								context: "import {$$$NAMES} from 'rimraf'",
+								strictness: 'relaxed',
+							},
+						},
+						{
+							pattern: {
+								context: "import $NAME from 'rimraf'",
+								strictness: 'relaxed',
+							},
+						},
+						{
+							pattern: {
+								context: "const {$$$NAMES} = require('rimraf')",
+								strictness: 'relaxed',
+							},
+						},
+						{
+							pattern: {
+								context: "const $NAME = require('rimraf')",
+								strictness: 'relaxed',
+							},
+						},
+					],
+				},
+			});
+
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			/** @type {Edit[]} */
+			const edits = [];
+			let quoteType = "'";
+			/** @type {string[]} */
+			const localNames = [];
+			let isCommonJS = false;
+
+			for (const imp of imports) {
+				const importSource = imp.field('source');
+				const requireCall = imp.find('require($SOURCE)');
+				let source = null;
+
+				if (importSource) {
+					// ESM
+					source = importSource.text();
+				} else {
+					// CJS
+					source = requireCall?.getMatch('SOURCE')?.text();
+				}
+
+				if (!source) {
+					continue;
+				}
+
+				if (!isCommonJS) {
+					isCommonJS = requireCall !== null;
+				}
+
+				if (source?.startsWith('"')) {
+					quoteType = '"';
+				}
+
+				const importedNames = imp.getMultipleMatches('NAMES');
+				const importedName = imp.getMatch('NAME');
+
+				// Its a default or namespace import
+				if (importedName) {
+					const importedNameText = importedName.text();
+					localNames.push(
+						importedNameText,
+						`${importedNameText}.$_METHOD`,
+						`${importedNameText}.$_METHOD.sync`,
+					);
+				}
+
+				for (const importSpecifier of importedNames) {
+					const importedName = importSpecifier.field('name');
+					const value = importSpecifier.field('value');
+
+					let localNameText;
+
+					if (importedName) {
+						// ESM
+						const localName = importSpecifier.field('alias') ?? importedName;
+						localNameText = localName.text();
+					} else if (value) {
+						// CJS
+						localNameText = value.text();
+					} else {
+						localNameText = importSpecifier.text();
+					}
+
+					localNames.push(localNameText, `${localNameText}.sync`);
+				}
+			}
+
+			const usagePatterns = [];
+			for (const name of localNames) {
+				usagePatterns.push(
+					{
+						pattern: `${name}($PATH, $OPTIONS)`,
+					},
+					{
+						pattern: `${name}($PATH)`,
+					},
+				);
+			}
+
+			const usages = root.findAll({
+				rule: {
+					any: usagePatterns,
+				},
+			});
+
+			let seenSync = false;
+			let seenAsync = false;
+			let seenGlob = false;
+
+			for (const usage of usages) {
+				const functionNode = usage.field('function');
+				const functionText = functionNode?.text();
+				const isSync =
+					functionText !== undefined &&
+					(functionText.includes('sync') || functionText?.includes('Sync'));
+
+				if (!seenSync) {
+					seenSync = isSync;
+				}
+				if (!seenAsync) {
+					seenAsync = !isSync;
+				}
+
+				const fsName = isSync ? 'rmSync' : 'rm';
+				const options = usage.getMatch('OPTIONS');
+				const path = usage.getMatch('PATH');
+				let optionsText = defaultOptions;
+
+				// Shouldn't be possible
+				if (path === null) {
+					continue;
+				}
+
+				if (options) {
+					if (options.kind() === 'object') {
+						const globOption = options
+							.children()
+							.find(
+								(child) =>
+									child.field('key')?.text() === 'glob' &&
+									child.field('value')?.text() !== 'false',
+							);
+						if (globOption) {
+							const globValue = globOption.field('value')?.text();
+							const globParams =
+								globValue !== null && globValue !== 'true'
+									? `${path.text()}, ${globValue}`
+									: path.text();
+							seenGlob = true;
+							// Indentation will be a mess, but do we care? use a formatter
+							edits.push(
+								usage.replace(
+									`
+Promise.all(
+  (await glob(${globParams})).map((filePath) =>
+    ${fsName}(filePath, ${defaultOptions}))
+)
+                `.trim(),
+								),
+							);
+							continue;
+						}
+
+						const optionsObjectText = options.text();
+						const bracketIndex = optionsObjectText.indexOf('{');
+						const beforeBracket = optionsObjectText.slice(0, bracketIndex);
+						const afterBracket = optionsObjectText.slice(bracketIndex + 1);
+						const afterBracketNextLine =
+							afterBracket.startsWith('\r') || afterBracket.startsWith('\n');
+						const afterBracketSpace = afterBracketNextLine ? '' : ' ';
+						optionsText = `${beforeBracket}{recursive: true, force: true,${afterBracketSpace}${afterBracket}`;
+					} else {
+						optionsText = options.text();
+					}
+				}
+
+				edits.push(usage.replace(`${fsName}(${path.text()}, ${optionsText})`));
+			}
+
+			if (imports.length > 0) {
+				const [firstImport, ...remainingImports] = imports;
+
+				let replacedImports = [];
+
+				if (seenAsync) {
+					replacedImports.push(
+						computeImport(isCommonJS, quoteType, ['rm'], 'node:fs/promises'),
+					);
+				}
+
+				if (seenSync) {
+					replacedImports.push(
+						computeImport(isCommonJS, quoteType, ['rmSync'], 'node:fs'),
+					);
+				}
+
+				if (seenGlob) {
+					replacedImports.push(
+						computeImport(isCommonJS, quoteType, ['glob'], 'tinyglobby'),
+					);
+				}
+
+				edits.push(firstImport.replace(replacedImports.join('\n')));
+
+				for (const imp of remainingImports) {
+					edits.push(imp.replace(''));
+				}
+			}
+
+			return root.commitEdits(edits);
+		},
+	};
+}

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ import qs from './codemods/qs/index.js';
 import reflectGetprototypeof from './codemods/reflect.getprototypeof/index.js';
 import reflectOwnkeys from './codemods/reflect.ownkeys/index.js';
 import regexpPrototypeFlags from './codemods/regexp.prototype.flags/index.js';
+import rimraf from './codemods/rimraf/index.js';
 import setprototypeof from './codemods/setprototypeof/index.js';
 import splitLines from './codemods/split-lines/index.js';
 import stringPrototypeAt from './codemods/string.prototype.at/index.js';
@@ -294,6 +295,7 @@ export const codemods = {
   "reflect.getprototypeof": reflectGetprototypeof,
   "reflect.ownkeys": reflectOwnkeys,
   "regexp.prototype.flags": regexpPrototypeFlags,
+  "rimraf": rimraf,
   "setprototypeof": setprototypeof,
   "split-lines": splitLines,
   "string.prototype.at": stringPrototypeAt,

--- a/test/fixtures/rimraf/cjs/after.js
+++ b/test/fixtures/rimraf/cjs/after.js
@@ -1,0 +1,13 @@
+const {rm} = require('node:fs/promises');
+const {rmSync} = require('node:fs');
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});

--- a/test/fixtures/rimraf/cjs/before.js
+++ b/test/fixtures/rimraf/cjs/before.js
@@ -1,0 +1,12 @@
+const {rimraf} = require('rimraf');
+
+await rimraf('./dist');
+
+export async function foo() {
+  await rimraf('./dist');
+
+  const someConst = './dist';
+  await rimraf(someConst);
+}
+
+rimraf.sync('./dist');

--- a/test/fixtures/rimraf/cjs/result.js
+++ b/test/fixtures/rimraf/cjs/result.js
@@ -1,0 +1,13 @@
+const {rm} = require('node:fs/promises');
+const {rmSync} = require('node:fs');
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});

--- a/test/fixtures/rimraf/esm/after.js
+++ b/test/fixtures/rimraf/esm/after.js
@@ -1,0 +1,39 @@
+import {rm} from 'node:fs/promises';
+import {glob} from 'tinyglobby';
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+// maxRetries
+await rm('./dist', {recursive: true, force: true, maxRetries: 10});
+
+// retryDelay
+await rm('./dist', {recursive: true, force: true, retryDelay: 1000});
+
+// glob
+await Promise.all(
+  (await glob('./dist/*.js')).map((filePath) =>
+    rm(filePath, {recursive: true, force: true}))
+);
+
+// glob options
+await Promise.all(
+  (await glob('./dist/*.js', {
+    dot: false
+  })).map((filePath) =>
+    rm(filePath, {recursive: true, force: true}))
+);
+
+// filter
+// Note: filters are not migrated yet
+await rm('./dist', {recursive: true, force: true,
+  filter: () => {
+    // some function, whatever
+  }
+});

--- a/test/fixtures/rimraf/esm/before.js
+++ b/test/fixtures/rimraf/esm/before.js
@@ -1,0 +1,34 @@
+import {rimraf} from 'rimraf';
+
+await rimraf('./dist');
+
+export async function foo() {
+  await rimraf('./dist');
+
+  const someConst = './dist';
+  await rimraf(someConst);
+}
+
+// maxRetries
+await rimraf('./dist', {maxRetries: 10});
+
+// retryDelay
+await rimraf('./dist', {retryDelay: 1000});
+
+// glob
+await rimraf('./dist/*.js', {glob: true});
+
+// glob options
+await rimraf('./dist/*.js', {
+  glob: {
+    dot: false
+  }
+});
+
+// filter
+// Note: filters are not migrated yet
+await rimraf('./dist', {
+  filter: () => {
+    // some function, whatever
+  }
+});

--- a/test/fixtures/rimraf/esm/result.js
+++ b/test/fixtures/rimraf/esm/result.js
@@ -1,0 +1,39 @@
+import {rm} from 'node:fs/promises';
+import {glob} from 'tinyglobby';
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+// maxRetries
+await rm('./dist', {recursive: true, force: true, maxRetries: 10});
+
+// retryDelay
+await rm('./dist', {recursive: true, force: true, retryDelay: 1000});
+
+// glob
+await Promise.all(
+  (await glob('./dist/*.js')).map((filePath) =>
+    rm(filePath, {recursive: true, force: true}))
+);
+
+// glob options
+await Promise.all(
+  (await glob('./dist/*.js', {
+    dot: false
+  })).map((filePath) =>
+    rm(filePath, {recursive: true, force: true}))
+);
+
+// filter
+// Note: filters are not migrated yet
+await rm('./dist', {recursive: true, force: true,
+  filter: () => {
+    // some function, whatever
+  }
+});

--- a/test/fixtures/rimraf/legacy-cjs/after.js
+++ b/test/fixtures/rimraf/legacy-cjs/after.js
@@ -1,0 +1,13 @@
+const {rm} = require('node:fs/promises');
+const {rmSync} = require('node:fs');
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});

--- a/test/fixtures/rimraf/legacy-cjs/before.js
+++ b/test/fixtures/rimraf/legacy-cjs/before.js
@@ -1,0 +1,12 @@
+const rimraf = require('rimraf');
+
+await rimraf('./dist');
+
+export async function foo() {
+  await rimraf('./dist');
+
+  const someConst = './dist';
+  await rimraf(someConst);
+}
+
+rimraf.sync('./dist');

--- a/test/fixtures/rimraf/legacy-cjs/result.js
+++ b/test/fixtures/rimraf/legacy-cjs/result.js
@@ -1,0 +1,13 @@
+const {rm} = require('node:fs/promises');
+const {rmSync} = require('node:fs');
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});

--- a/test/fixtures/rimraf/legacy-esm/after.js
+++ b/test/fixtures/rimraf/legacy-esm/after.js
@@ -1,0 +1,13 @@
+import {rm} from 'node:fs/promises';
+import {rmSync} from 'node:fs';
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});

--- a/test/fixtures/rimraf/legacy-esm/before.js
+++ b/test/fixtures/rimraf/legacy-esm/before.js
@@ -1,0 +1,12 @@
+import rimraf from 'rimraf';
+
+await rimraf('./dist');
+
+export async function foo() {
+  await rimraf('./dist');
+
+  const someConst = './dist';
+  await rimraf(someConst);
+}
+
+rimraf.sync('./dist');

--- a/test/fixtures/rimraf/legacy-esm/result.js
+++ b/test/fixtures/rimraf/legacy-esm/result.js
@@ -1,0 +1,13 @@
+import {rm} from 'node:fs/promises';
+import {rmSync} from 'node:fs';
+
+await rm('./dist', {recursive: true, force: true});
+
+export async function foo() {
+  await rm('./dist', {recursive: true, force: true});
+
+  const someConst = './dist';
+  await rm(someConst, {recursive: true, force: true});
+}
+
+rmSync('./dist', {recursive: true, force: true});


### PR DESCRIPTION
Adds a new codemod to migrate from `rimraf`.

It will use `rm` or `rmSync` where appropriate.

If `glob` is set, it will use `tinyglobby` to find the files and later `rm` or `rmSync` them.