### PR TITLE
feat: migrate `array.of` to ast-grep

### DIFF
--- a/codemods/array.of/index.js
+++ b/codemods/array.of/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.of';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,30 +14,54 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.of',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const { identifier } = removeImport('array.of', root, j);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: { name: identifier },
-				})
-				.forEach((p) => {
-					dirtyFlag = true;
-					j(p).replaceWith(
-						j.callExpression(
-							j.memberExpression(j.identifier('Array'), j.identifier('of')),
-							p.value.arguments,
-						),
-					);
-				});
+			if (imports.length === 0) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (argsMatch) {
+					const argsText = argsMatch
+						.filter((m) => m.kind() !== ',')
+						.map((m) => m.text())
+						.join(', ');
+					edits.push(call.replace(`Array.of(${argsText})`));
+				}
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -113,6 +113,12 @@ export function findNamedDefaultImport(root, moduleName) {
 						strictness: 'relaxed',
 					},
 				},
+				{
+					pattern: {
+						context: `var $NAME = require('${moduleName}')`,
+						strictness: 'relaxed',
+					},
+				},
 			],
 		},
 	});

--- a/test/fixtures/array.of/case-1/after.js
+++ b/test/fixtures/array.of/case-1/after.js
@@ -1,3 +1,4 @@
 var assert = require("assert");
 
+
 assert.deepEqual(Array.of(1, 2, 3), [1, 2, 3]);

--- a/test/fixtures/array.of/case-1/result.js
+++ b/test/fixtures/array.of/case-1/result.js
@@ -1,3 +1,4 @@
 var assert = require("assert");
 
+
 assert.deepEqual(Array.of(1, 2, 3), [1, 2, 3]);

--- a/test/fixtures/array.of/case-2/after.js
+++ b/test/fixtures/array.of/case-2/after.js
@@ -1,0 +1,4 @@
+
+
+const arr = Array.of(1, 2, 3);
+console.log(arr);

--- a/test/fixtures/array.of/case-2/before.js
+++ b/test/fixtures/array.of/case-2/before.js
@@ -1,0 +1,4 @@
+import arrayOf from 'array.of';
+
+const arr = arrayOf(1, 2, 3);
+console.log(arr);

--- a/test/fixtures/array.of/case-2/result.js
+++ b/test/fixtures/array.of/case-2/result.js
@@ -1,0 +1,4 @@
+
+
+const arr = Array.of(1, 2, 3);
+console.log(arr);


### PR DESCRIPTION
See #111

This migrates the codemod to use ast-grep

Used some assistance from AI
