### PR TITLE
feat: migrate `array-buffer-byte-length` to ast-grep

### DIFF
--- a/codemods/array-buffer-byte-length/index.js
+++ b/codemods/array-buffer-byte-length/index.js
@@ -44,16 +44,17 @@ export default function (options) {
 				const argsMatch = call.getMultipleMatches('ARG');
 				if (!argsMatch) continue;
 
-				const args = argsMatch
-					.filter((m) => m.kind() !== ',')
-					.map((m) => m.text());
+				const argNodes = argsMatch.filter((m) => m.kind() !== ',');
 
-				if (args.length !== 1) continue;
+				if (argNodes.length !== 1) continue;
 
-				const argText = args[0];
+				const argNode = argNodes[0];
+				const argText = argNode.text();
 
-				const isIdentifier = argText.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/);
-				const isNewArrayBuffer = argText.startsWith('new ArrayBuffer');
+				const isIdentifier = argNode.kind() === 'identifier';
+				const isNewArrayBuffer =
+					argNode.kind() === 'new_expression' &&
+					argText.startsWith('new ArrayBuffer');
 
 				if (isIdentifier || isNewArrayBuffer) {
 					edits.push(call.replace(`${argText}.byteLength`));

--- a/codemods/array-buffer-byte-length/index.js
+++ b/codemods/array-buffer-byte-length/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { removeImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array-buffer-byte-length';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,38 +14,53 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array-buffer-byte-length',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const { identifier } = removeImport('array-buffer-byte-length', root, j);
+			const { edits: importEdits, localNames } = removeImport(
+				root,
+				MODULE_NAME,
+			);
 
-			let dirtyFlag = false;
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const [bufferArg] = path.node.arguments;
-					if (
-						j.Identifier.check(bufferArg) ||
-						(j.NewExpression.check(bufferArg) &&
-							bufferArg.callee.type === 'Identifier' &&
-							bufferArg.callee.name === 'ArrayBuffer')
-					) {
-						path.replace(
-							j.memberExpression(bufferArg, j.identifier('byteLength')),
-						);
-						dirtyFlag = true;
-					}
-				});
+			if (localNames.length === 0) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			edits.push(...importEdits);
+
+			const identifierName = localNames[0];
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARG)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARG');
+				if (!argsMatch) continue;
+
+				const args = argsMatch
+					.filter((m) => m.kind() !== ',')
+					.map((m) => m.text());
+
+				if (args.length !== 1) continue;
+
+				const argText = args[0];
+
+				const isIdentifier = argText.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/);
+				const isNewArrayBuffer = argText.startsWith('new ArrayBuffer');
+
+				if (isIdentifier || isNewArrayBuffer) {
+					edits.push(call.replace(`${argText}.byteLength`));
+				}
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array-buffer-byte-length/case-1/after.js
+++ b/test/fixtures/array-buffer-byte-length/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(
   new ArrayBuffer(0).byteLength,
   0,

--- a/test/fixtures/array-buffer-byte-length/case-1/result.js
+++ b/test/fixtures/array-buffer-byte-length/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(
   new ArrayBuffer(0).byteLength,
   0,


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array-buffer-byte-length` codemod to use ast-grep
