### PR TITLE
feat: migrate `array-includes` to ast-grep

### DIFF
--- a/codemods/array-includes/index.js
+++ b/codemods/array-includes/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array-includes';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,38 +14,58 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array-includes',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const { identifier } = removeImport('array-includes', root, j);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 2 || args.length === 3) {
-						const [array, ...otherArgs] = args;
+			if (imports.length === 0) {
+				return file.source;
+			}
 
-						const newExpression = j.callExpression(
-							//@ts-ignore
-							j.memberExpression(array, j.identifier('includes')),
-							otherArgs,
-						);
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (argsMatch) {
+					const args = argsMatch.filter((m) => m.kind() !== ',');
+					if (args.length >= 2) {
+						const arrayText = args[0].text();
+						const searchArgs = args
+							.slice(1)
+							.map((m) => m.text())
+							.join(', ');
+						edits.push(call.replace(`${arrayText}.includes(${searchArgs})`));
 					}
-				});
+				}
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array-includes/case-1/after.js
+++ b/test/fixtures/array-includes/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 var arr = ["one", "two"];
 

--- a/test/fixtures/array-includes/case-1/result.js
+++ b/test/fixtures/array-includes/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 var arr = ["one", "two"];
 


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array-includes` codemod to use ast-grep
