### PR TITLE
feat: migrate `array.prototype.at` to ast-grep

### DIFF
--- a/codemods/array.prototype.at/index.js
+++ b/codemods/array.prototype.at/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.prototype.at';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -19,15 +21,57 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.prototype.at',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod('array.prototype.at', 'at', root, j);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (!argsMatch) continue;
+
+				const argNodes = argsMatch.filter((m) => m.kind() !== ',');
+
+				if (argNodes.length !== 2) continue;
+
+				const arrayText = argNodes[0].text();
+				const indexText = argNodes[1].text();
+
+				edits.push(call.replace(`${arrayText}.at(${indexText})`));
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array.prototype.at/case-1/after.js
+++ b/test/fixtures/array.prototype.at/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 
+
 const arr = [1, 2];
 
 assert.equal(arr.at(0), arr[0]);

--- a/test/fixtures/array.prototype.at/case-1/result.js
+++ b/test/fixtures/array.prototype.at/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 
+
 const arr = [1, 2];
 
 assert.equal(arr.at(0), arr[0]);


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array.prototype.at` codemod to use ast-grep
