### PR TITLE
feat: migrate `array.prototype.every` to ast-grep

### DIFF
--- a/codemods/array.prototype.every/index.js
+++ b/codemods/array.prototype.every/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.prototype.every';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +14,55 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.prototype.every',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod(
-				'array.prototype.every',
-				'every',
-				root,
-				j,
-			);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$ARRAY, $$CALLBACK)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const arrayMatch = call.getMatch('ARRAY');
+				if (!arrayMatch) continue;
+				const callbackMatch = call.getMatch('CALLBACK');
+				if (!callbackMatch) continue;
+
+				const arrayText = arrayMatch.text();
+				const callbackText = callbackMatch.text();
+
+				edits.push(call.replace(`${arrayText}.every(${callbackText})`));
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/array.prototype.every/index.js
+++ b/codemods/array.prototype.every/index.js
@@ -26,7 +26,6 @@ export default function (options) {
 				MODULE_NAME,
 			);
 
-
 			if (!identifierName) {
 				return file.source;
 			}

--- a/codemods/array.prototype.every/index.js
+++ b/codemods/array.prototype.every/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.every';
 
@@ -21,20 +21,11 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/array.prototype.every/index.js
+++ b/codemods/array.prototype.every/index.js
@@ -32,7 +32,7 @@ export default function (options) {
 
 			const callExpressions = root.findAll({
 				rule: {
-					pattern: `${identifierName}($$ARRAY, $$CALLBACK)`,
+					pattern: `${identifierName}($ARRAY, $CALLBACK)`,
 				},
 			});
 

--- a/test/fixtures/array.prototype.every/case-1/after.js
+++ b/test/fixtures/array.prototype.every/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(

--- a/test/fixtures/array.prototype.every/case-1/result.js
+++ b/test/fixtures/array.prototype.every/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array.prototype.every` codemod to use ast-grep
