### PR TITLE
feat: migrate `array.prototype.filter` to ast-grep

### DIFF
--- a/codemods/array.prototype.filter/index.js
+++ b/codemods/array.prototype.filter/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.prototype.filter';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +14,60 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.prototype.filter',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod(
-				'array.prototype.filter',
-				'filter',
-				root,
-				j,
-			);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (!argsMatch) continue;
+
+				const argNodes = argsMatch.filter((m) => m.kind() !== ',');
+
+				if (argNodes.length < 2) continue;
+
+				const arrayText = argNodes[0].text();
+				const predicateText = argNodes
+					.slice(1)
+					.map((m) => m.text())
+					.join(', ');
+
+				edits.push(call.replace(`${arrayText}.filter(${predicateText})`));
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/array.prototype.filter/index.js
+++ b/codemods/array.prototype.filter/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.filter';
 
@@ -21,20 +21,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/test/fixtures/array.prototype.filter/case-1/after.js
+++ b/test/fixtures/array.prototype.filter/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-1/result.js
+++ b/test/fixtures/array.prototype.filter/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-2/after.js
+++ b/test/fixtures/array.prototype.filter/case-2/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-2/result.js
+++ b/test/fixtures/array.prototype.filter/case-2/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-3/after.js
+++ b/test/fixtures/array.prototype.filter/case-3/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-3/result.js
+++ b/test/fixtures/array.prototype.filter/case-3/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-4/after.js
+++ b/test/fixtures/array.prototype.filter/case-4/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.filter/case-4/result.js
+++ b/test/fixtures/array.prototype.filter/case-4/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array.prototype.filter` codemod to use ast-grep
