### PR TITLE
feat: migrate `array.prototype.find` to ast-grep

### DIFF
--- a/codemods/array.prototype.find/index.js
+++ b/codemods/array.prototype.find/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.find';
 
@@ -21,20 +21,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/array.prototype.find/index.js
+++ b/codemods/array.prototype.find/index.js
@@ -32,7 +32,7 @@ export default function (options) {
 
 			const callExpressions = root.findAll({
 				rule: {
-					pattern: `${identifierName}($$ARRAY, $$CALLBACK)`,
+					pattern: `${identifierName}($ARRAY, $CALLBACK)`,
 				},
 			});
 

--- a/codemods/array.prototype.find/index.js
+++ b/codemods/array.prototype.find/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findNamedDefaultImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.prototype.find';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +14,53 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.prototype.find',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod(
-				'array.prototype.find',
-				'find',
-				root,
-				j,
-			);
+			const imports = findNamedDefaultImport(root, MODULE_NAME);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (imports.length === 0) {
+				return file.source;
+			}
+
+			let identifierName = null;
+			for (const imp of imports) {
+				const nameMatch = imp.getMatch('NAME');
+				if (nameMatch) {
+					identifierName = nameMatch.text();
+					break;
+				}
+			}
+
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$ARRAY, $$CALLBACK)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const arrayMatch = call.getMatch('ARRAY');
+				const callbackMatch = call.getMatch('CALLBACK');
+				if (!arrayMatch || !callbackMatch) continue;
+				const arrayText = arrayMatch.text();
+				const callbackText = callbackMatch.text();
+
+				edits.push(call.replace(`${arrayText}.find(${callbackText})`));
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array.prototype.find/case-1/after.js
+++ b/test/fixtures/array.prototype.find/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-1/result.js
+++ b/test/fixtures/array.prototype.find/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-2/after.js
+++ b/test/fixtures/array.prototype.find/case-2/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-2/result.js
+++ b/test/fixtures/array.prototype.find/case-2/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-3/after.js
+++ b/test/fixtures/array.prototype.find/case-3/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-3/result.js
+++ b/test/fixtures/array.prototype.find/case-3/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-4/after.js
+++ b/test/fixtures/array.prototype.find/case-4/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.find/case-4/result.js
+++ b/test/fixtures/array.prototype.find/case-4/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array.prototype.find` codemod to use ast-grep
