### PR TITLE
chore: extract common call expression utils

### DIFF
--- a/codemods/array-includes/index.js
+++ b/codemods/array-includes/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array-includes';
 
@@ -21,20 +21,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/array.of/index.js
+++ b/codemods/array.of/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import {
+	computeSimpleCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.of';
 
@@ -19,43 +22,21 @@ export default function (options) {
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
 			const root = ast.root();
-			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;
 			}
 
-			const callExpressions = root.findAll({
-				rule: {
-					pattern: `${identifierName}($$$ARGS)`,
-				},
-			});
-
-			for (const call of callExpressions) {
-				const argsMatch = call.getMultipleMatches('ARGS');
-				if (argsMatch) {
-					const argsText = argsMatch
-						.filter((m) => m.kind() !== ',')
-						.map((m) => m.text())
-						.join(', ');
-					edits.push(call.replace(`Array.of(${argsText})`));
-				}
-			}
+			const edits = computeSimpleCallReplacementEdits(
+				root,
+				identifierName,
+				'Array.of',
+			);
 
 			for (const imp of imports) {
 				edits.push(imp.replace(''));

--- a/codemods/array.prototype.at/index.js
+++ b/codemods/array.prototype.at/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.at';
 
@@ -28,20 +28,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/array.prototype.concat/index.js
+++ b/codemods/array.prototype.concat/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.concat';
 
@@ -21,20 +21,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/array.prototype.copywithin/index.js
+++ b/codemods/array.prototype.copywithin/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { findNamedDefaultImport } from '../shared-ast-grep.js';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array.prototype.copywithin';
 
@@ -21,20 +21,10 @@ export default function (options) {
 			const root = ast.root();
 			const edits = [];
 
-			const imports = findNamedDefaultImport(root, MODULE_NAME);
-
-			if (imports.length === 0) {
-				return file.source;
-			}
-
-			let identifierName = null;
-			for (const imp of imports) {
-				const nameMatch = imp.getMatch('NAME');
-				if (nameMatch) {
-					identifierName = nameMatch.text();
-					break;
-				}
-			}
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
 			if (!identifierName) {
 				return file.source;

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -127,6 +127,60 @@ export function findNamedDefaultImport(root, moduleName) {
 }
 
 /**
+ * Find default imports of a module and resolve the local identifier name.
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} moduleName - The module to find imports for.
+ * @returns {{ imports: SgNode[], identifierName: string | null }}
+ */
+export function findDefaultImportIdentifier(root, moduleName) {
+	const imports = findNamedDefaultImport(root, moduleName);
+	let identifierName = null;
+	for (const imp of imports) {
+		const nameMatch = imp.getMatch('NAME');
+		if (nameMatch) {
+			identifierName = nameMatch.text();
+			break;
+		}
+	}
+	return { imports, identifierName };
+}
+
+/**
+ * Compute edits that replace every call of `fromIdentifier(...)` with
+ * `toCallee(...)`, preserving the original argument list verbatim.
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} fromIdentifier - The identifier currently being called.
+ * @param {string} toCallee - The replacement callee expression (e.g. `Array.of`).
+ * @returns {Edit[]}
+ */
+export function computeSimpleCallReplacementEdits(
+	root,
+	fromIdentifier,
+	toCallee,
+) {
+	/** @type {Edit[]} */
+	const edits = [];
+	const calls = root.findAll({
+		rule: {
+			pattern: `${fromIdentifier}($$$ARGS)`,
+		},
+	});
+	for (const call of calls) {
+		const argsMatch = call.getMultipleMatches('ARGS');
+		const argsText = argsMatch
+			? argsMatch
+					.filter((m) => m.kind() !== ',')
+					.map((m) => m.text())
+					.join(', ')
+			: '';
+		edits.push(call.replace(`${toCallee}(${argsText})`));
+	}
+	return edits;
+}
+
+/**
  * Replace a default import/require of one package with another.
  *
  * @param {SgNode} root - The root of the AST.


### PR DESCRIPTION

### 🔗 Linked issue

N/A

### 📚 Description

This adds two new utils:

- `findDefaultImportIdentifier` to find imports and a name for a given
	module
- `computeSimpleCallReplacementEdits` to do a basic `foo($ARGS)` ->
	`bar($ARGS)` edit (i.e. just changing the name)

cc @gameroman this should make those migrations simpler/smaller
