### PR TITLE
feat: migrate `array-every` to ast-grep

### DIFF
--- a/codemods/array-every/index.js
+++ b/codemods/array-every/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array-every';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,15 +14,45 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array-every',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod('array-every', 'every', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (argsMatch) {
+					const args = argsMatch.filter((m) => m.kind() !== ',');
+					if (args.length === 2) {
+						const arrayText = args[0].text();
+						const fnText = args[1].text();
+						edits.push(call.replace(`${arrayText}.every(${fnText})`));
+					}
+				}
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array-every/case-1/after.js
+++ b/test/fixtures/array-every/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var result = ["a", "b", "c"].every(function (ele) {

--- a/test/fixtures/array-every/case-1/result.js
+++ b/test/fixtures/array-every/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var result = ["a", "b", "c"].every(function (ele) {

--- a/test/fixtures/array-every/imports-only/after.js
+++ b/test/fixtures/array-every/imports-only/after.js
@@ -1,1 +1,3 @@
+
+
 export const n = 303;

--- a/test/fixtures/array-every/imports-only/result.js
+++ b/test/fixtures/array-every/imports-only/result.js
@@ -1,1 +1,3 @@
+
+
 export const n = 303;


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array-every` codemod to use ast-grep
