### PR TITLE
feat: migrate `array.prototype.flat` to ast-grep

### DIFF
--- a/codemods/array.prototype.flat/index.js
+++ b/codemods/array.prototype.flat/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { transformArrayMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { findDefaultImportIdentifier } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'array.prototype.flat';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +14,46 @@ import { transformArrayMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'array.prototype.flat',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const edits = [];
 
-			const dirty = transformArrayMethod(
-				'array.prototype.flat',
-				'flat',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const callExpressions = root.findAll({
+				rule: {
+					pattern: `${identifierName}($$$ARGS)`,
+				},
+			});
+
+			for (const call of callExpressions) {
+				const argsMatch = call.getMultipleMatches('ARGS');
+				if (!argsMatch) continue;
+				const args = argsMatch.filter((m) => m.kind() !== ',');
+				if (args.length < 1) continue;
+				const arrayText = args[0].text();
+				const flatArgs = args
+					.slice(1)
+					.map((m) => m.text())
+					.join(', ');
+				edits.push(call.replace(`${arrayText}.flat(${flatArgs})`));
+			}
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/array.prototype.flat/case-1/after.js
+++ b/test/fixtures/array.prototype.flat/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-1/result.js
+++ b/test/fixtures/array.prototype.flat/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-2/after.js
+++ b/test/fixtures/array.prototype.flat/case-2/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-2/result.js
+++ b/test/fixtures/array.prototype.flat/case-2/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-3/after.js
+++ b/test/fixtures/array.prototype.flat/case-3/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-3/result.js
+++ b/test/fixtures/array.prototype.flat/case-3/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-4/after.js
+++ b/test/fixtures/array.prototype.flat/case-4/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(

--- a/test/fixtures/array.prototype.flat/case-4/result.js
+++ b/test/fixtures/array.prototype.flat/case-4/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 assert.deepEqual(


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `array.prototype.flat` codemod to use ast-grep
