### PR TITLE
feat: migrate `typed-array-*` codemods to ast-grep

### DIFF
--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -290,6 +290,34 @@ export function replaceDefaultImport(
 }
 
 /**
+ * Compute edits that replace every call of `identifierName(arg)` with
+ * `arg.propertyName`, converting a polyfill function call to a native property access.
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} identifierName - The identifier currently being called.
+ * @param {string} propertyName - The native property name to replace with (e.g., 'length').
+ * @returns {Edit[]}
+ */
+export function computePolyfillPropertyReplacementEdits(
+	root,
+	identifierName,
+	propertyName,
+) {
+	/** @type {Edit[]} */
+	const edits = [];
+	const calls = root.findAll({
+		rule: { pattern: `${identifierName}($ARG)` },
+	});
+	for (const call of calls) {
+		const arg = call.getMatch('ARG');
+		if (arg) {
+			edits.push(call.replace(`${arg.text()}.${propertyName}`));
+		}
+	}
+	return edits;
+}
+
+/**
  * Replace a default import/require of one package with a named import from another package.
  *
  * @param {SgNode} root - The root of the AST.

--- a/codemods/typed-array-buffer/index.js
+++ b/codemods/typed-array-buffer/index.js
@@ -1,6 +1,11 @@
-import jscodeshift from 'jscodeshift';
-import { ALL_TYPED_ARRAY_OBJECTS } from '../CONSTANTS.js';
-import { removeImport, transformInstanceProperty } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillPropertyReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'typed-array-buffer';
+const PROPERTY_NAME = 'buffer';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -13,39 +18,24 @@ import { removeImport, transformInstanceProperty } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'typed-array-buffer',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirty = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('typed-array-buffer', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					for (const typedArrayObject of ALL_TYPED_ARRAY_OBJECTS) {
-						const dirtyFlag = transformInstanceProperty(
-							path,
-							typedArrayObject,
-							'buffer',
-							j,
-						);
+			for (const name of localNames) {
+				const propEdits = computePolyfillPropertyReplacementEdits(
+					root,
+					name,
+					PROPERTY_NAME,
+				);
+				edits.push(...propEdits);
+			}
 
-						if (dirtyFlag) {
-							dirty = true;
-							break;
-						}
-					}
-				});
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/typed-array-byte-length/index.js
+++ b/codemods/typed-array-byte-length/index.js
@@ -1,6 +1,11 @@
-import jscodeshift from 'jscodeshift';
-import { ALL_TYPED_ARRAY_OBJECTS } from '../CONSTANTS.js';
-import { removeImport, transformInstanceProperty } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillPropertyReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'typed-array-byte-length';
+const PROPERTY_NAME = 'byteLength';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -13,39 +18,24 @@ import { removeImport, transformInstanceProperty } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'typed-array-byte-length',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirty = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('typed-array-byte-length', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					for (const typedArrayObject of ALL_TYPED_ARRAY_OBJECTS) {
-						const dirtyFlag = transformInstanceProperty(
-							path,
-							typedArrayObject,
-							'byteLength',
-							j,
-						);
+			for (const name of localNames) {
+				const propEdits = computePolyfillPropertyReplacementEdits(
+					root,
+					name,
+					PROPERTY_NAME,
+				);
+				edits.push(...propEdits);
+			}
 
-						if (dirtyFlag) {
-							dirty = true;
-							break;
-						}
-					}
-				});
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/typed-array-byte-offset/index.js
+++ b/codemods/typed-array-byte-offset/index.js
@@ -1,6 +1,11 @@
-import jscodeshift from 'jscodeshift';
-import { ALL_TYPED_ARRAY_OBJECTS } from '../CONSTANTS.js';
-import { removeImport, transformInstanceProperty } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillPropertyReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'typed-array-byte-offset';
+const PROPERTY_NAME = 'byteOffset';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -13,39 +18,24 @@ import { removeImport, transformInstanceProperty } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'typed-array-byte-offset',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirty = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('typed-array-byte-offset', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					for (const typedArrayObject of ALL_TYPED_ARRAY_OBJECTS) {
-						const dirtyFlag = transformInstanceProperty(
-							path,
-							typedArrayObject,
-							'byteOffset',
-							j,
-						);
+			for (const name of localNames) {
+				const propEdits = computePolyfillPropertyReplacementEdits(
+					root,
+					name,
+					PROPERTY_NAME,
+				);
+				edits.push(...propEdits);
+			}
 
-						if (dirtyFlag) {
-							dirty = true;
-							break;
-						}
-					}
-				});
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/typed-array-length/index.js
+++ b/codemods/typed-array-length/index.js
@@ -1,6 +1,11 @@
-import jscodeshift from 'jscodeshift';
-import { ALL_TYPED_ARRAY_OBJECTS } from '../CONSTANTS.js';
-import { removeImport, transformInstanceProperty } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillPropertyReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'typed-array-length';
+const PROPERTY_NAME = 'length';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -13,39 +18,24 @@ import { removeImport, transformInstanceProperty } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'typed-array-length',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirty = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('typed-array-length', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					for (const typedArrayObject of ALL_TYPED_ARRAY_OBJECTS) {
-						const dirtyFlag = transformInstanceProperty(
-							path,
-							typedArrayObject,
-							'length',
-							j,
-						);
+			for (const name of localNames) {
+				const propEdits = computePolyfillPropertyReplacementEdits(
+					root,
+					name,
+					PROPERTY_NAME,
+				);
+				edits.push(...propEdits);
+			}
 
-						if (dirtyFlag) {
-							dirty = true;
-							break;
-						}
-					}
-				});
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/typed-array-buffer/case-1/after.js
+++ b/test/fixtures/typed-array-buffer/case-1/after.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.buffer);
 console.log(new Int8Array(0).buffer);

--- a/test/fixtures/typed-array-buffer/case-1/result.js
+++ b/test/fixtures/typed-array-buffer/case-1/result.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.buffer);
 console.log(new Int8Array(0).buffer);

--- a/test/fixtures/typed-array-byte-length/case-1/after.js
+++ b/test/fixtures/typed-array-byte-length/case-1/after.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.byteLength);
 console.log(new Int8Array(0).byteLength);

--- a/test/fixtures/typed-array-byte-length/case-1/result.js
+++ b/test/fixtures/typed-array-byte-length/case-1/result.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.byteLength);
 console.log(new Int8Array(0).byteLength);

--- a/test/fixtures/typed-array-byte-offset/case-1/after.js
+++ b/test/fixtures/typed-array-byte-offset/case-1/after.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.byteOffset);
 console.log(new Int8Array(0).byteOffset);

--- a/test/fixtures/typed-array-byte-offset/case-1/result.js
+++ b/test/fixtures/typed-array-byte-offset/case-1/result.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.byteOffset);
 console.log(new Int8Array(0).byteOffset);

--- a/test/fixtures/typed-array-length/case-1/after.js
+++ b/test/fixtures/typed-array-length/case-1/after.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.length);
 console.log(new Int8Array(0).length);

--- a/test/fixtures/typed-array-length/case-1/result.js
+++ b/test/fixtures/typed-array-length/case-1/result.js
@@ -1,3 +1,5 @@
+
+
 const int8Array = new Int8Array(0);
 console.log(int8Array.length);
 console.log(new Int8Array(0).length);


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `typed-array-*` codemods to ast-grep
