### PR TITLE
feat: migrate `math.*` codemods to ast-grep

### DIFF
--- a/codemods/abort-controller/index.js
+++ b/codemods/abort-controller/index.js
@@ -1,5 +1,5 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -17,14 +17,12 @@ export default function (options) {
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
 			const root = ast.root();
-
-			const { edits } = removeImport(root, 'abort-controller');
-
-			if (edits.length === 0) {
-				return file.source;
-			}
-
-			return root.commitEdits(edits);
+			const { edits } = replacePolyfillUsage(
+				root,
+				'abort-controller',
+				'AbortController',
+			);
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/abort-controller/index.js
+++ b/codemods/abort-controller/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'abort-controller';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,14 +14,14 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'abort-controller',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
 			const root = ast.root();
 			const { edits } = replacePolyfillUsage(
 				root,
-				'abort-controller',
+				MODULE_NAME,
 				'AbortController',
 			);
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/chalk/index.js
+++ b/codemods/chalk/index.js
@@ -1,5 +1,7 @@
 import { ts } from '@ast-grep/napi';
 
+const MODULE_NAME = 'chalk';
+
 const picoNames = [
 	'isColorSupported',
 	'reset',
@@ -58,7 +60,7 @@ const picoNames = [
  */
 export default function (options) {
 	return {
-		name: 'chalk',
+		name: MODULE_NAME,
 		to: 'picocolors',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/globalthis/index.js
+++ b/codemods/globalthis/index.js
@@ -1,5 +1,7 @@
 import { ts } from '@ast-grep/napi';
 
+const MODULE_NAME = 'globalthis';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -11,7 +13,7 @@ import { ts } from '@ast-grep/napi';
  */
 export default function (options) {
 	return {
-		name: 'globalthis',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/invariant/index.js
+++ b/codemods/invariant/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replaceDefaultImport } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'invariant';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replaceDefaultImport } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'invariant',
+		name: MODULE_NAME,
 		to: 'tiny-invariant',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
@@ -20,7 +22,7 @@ export default function (options) {
 
 			const { edits } = replaceDefaultImport(
 				root,
-				'invariant',
+				MODULE_NAME,
 				'tiny-invariant',
 			);
 

--- a/codemods/iterate-iterator/index.js
+++ b/codemods/iterate-iterator/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { removeImport } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'iterate-iterator';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,13 +14,13 @@ import { removeImport } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'iterate-iterator',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
 			const root = ast.root();
 
-			const { edits, localNames } = removeImport(root, 'iterate-iterator');
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
 			for (const importName of localNames) {
 				const singleArgCalls = root.findAll({

--- a/codemods/iterate-value/index.js
+++ b/codemods/iterate-value/index.js
@@ -1,5 +1,7 @@
 import { ts } from '@ast-grep/napi';
 
+const MODULE_NAME = 'iterate-value';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -11,7 +13,7 @@ import { ts } from '@ast-grep/napi';
  */
 export default function (options) {
 	return {
-		name: 'iterate-value',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.acosh/index.js
+++ b/codemods/math.acosh/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.acosh';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.acosh',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.acosh/index.js
+++ b/codemods/math.acosh/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.acosh',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.acosh/polyfill',
-				'acosh',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.acosh/polyfill',
+				'Math.acosh',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.atanh/index.js
+++ b/codemods/math.atanh/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.atanh',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.atanh/polyfill',
-				'atanh',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.atanh/polyfill',
+				'Math.atanh',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.atanh/index.js
+++ b/codemods/math.atanh/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.atanh';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.atanh',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.cbrt/index.js
+++ b/codemods/math.cbrt/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.cbrt',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.cbrt/polyfill',
-				'cbrt',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.cbrt/polyfill',
+				'Math.cbrt',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.cbrt/index.js
+++ b/codemods/math.cbrt/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.cbrt';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.cbrt',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.clz32/index.js
+++ b/codemods/math.clz32/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.clz32';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.clz32',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.clz32/index.js
+++ b/codemods/math.clz32/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.clz32',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.clz32/polyfill',
-				'clz32',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.clz32/polyfill',
+				'Math.clz32',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.f16round/index.js
+++ b/codemods/math.f16round/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,12 +15,14 @@ export default function (options) {
 		name: 'math.f16round',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill('math.f16round', 'f16round', root, j);
-
-			return dirty ? root.toSource(options) : file.source;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
+				root,
+				'math.f16round',
+				'Math.f16round',
+			);
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.f16round/index.js
+++ b/codemods/math.f16round/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.f16round';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,14 +14,14 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.f16round',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
 			const root = ast.root();
 			const { edits } = replacePolyfillUsage(
 				root,
-				'math.f16round',
+				MODULE_NAME,
 				'Math.f16round',
 			);
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/math.fround/index.js
+++ b/codemods/math.fround/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.fround';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.fround',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.fround/index.js
+++ b/codemods/math.fround/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.fround',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.fround/polyfill',
-				'fround',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.fround/polyfill',
+				'Math.fround',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.imul/index.js
+++ b/codemods/math.imul/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.imul';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.imul',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.imul/index.js
+++ b/codemods/math.imul/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.imul',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.imul/polyfill',
-				'imul',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.imul/polyfill',
+				'Math.imul',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.log10/index.js
+++ b/codemods/math.log10/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.log10',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.log10/polyfill',
-				'log10',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.log10/polyfill',
+				'Math.log10',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.log10/index.js
+++ b/codemods/math.log10/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.log10';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.log10',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.log1p/index.js
+++ b/codemods/math.log1p/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.log1p',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.log1p/polyfill',
-				'log1p',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.log1p/polyfill',
+				'Math.log1p',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.log1p/index.js
+++ b/codemods/math.log1p/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.log1p';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.log1p',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/math.sign/index.js
+++ b/codemods/math.sign/index.js
@@ -1,5 +1,5 @@
-import jscodeshift from 'jscodeshift';
-import { transformMathPolyfill } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,17 +15,14 @@ export default function (options) {
 		name: 'math.sign',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-
-			const dirty = transformMathPolyfill(
-				'math.sign/polyfill',
-				'sign',
+			const ast = ts.parse(file.source);
+			const root = ast.root();
+			const { edits } = replacePolyfillUsage(
 				root,
-				j,
+				'math.sign/polyfill',
+				'Math.sign',
 			);
-
-			return dirty ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/math.sign/index.js
+++ b/codemods/math.sign/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replacePolyfillUsage } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'math.sign';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replacePolyfillUsage } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'math.sign',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/md5/index.js
+++ b/codemods/md5/index.js
@@ -1,6 +1,8 @@
 import { ts } from '@ast-grep/napi';
 import { replaceDefaultImport } from '../shared-ast-grep.js';
 
+const MODULE_NAME = 'md5';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -12,7 +14,7 @@ import { replaceDefaultImport } from '../shared-ast-grep.js';
  */
 export default function (options) {
 	return {
-		name: 'md5',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);
@@ -20,7 +22,7 @@ export default function (options) {
 
 			const { edits, localNames, quoteType } = replaceDefaultImport(
 				root,
-				'md5',
+				MODULE_NAME,
 				'crypto',
 				'crypto',
 			);

--- a/codemods/qs/index.js
+++ b/codemods/qs/index.js
@@ -1,5 +1,7 @@
 import { ts } from '@ast-grep/napi';
 
+const MODULE_NAME = 'qs';
+
 const qsLikeOptions = {
 	nesting: true,
 	nestingSyntax: 'js',
@@ -131,7 +133,7 @@ const replacements = {
  */
 export default function (options) {
 	return {
-		name: 'qs',
+		name: MODULE_NAME,
 		to: 'picoquery',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/rimraf/index.js
+++ b/codemods/rimraf/index.js
@@ -1,5 +1,7 @@
 import { ts } from '@ast-grep/napi';
 
+const MODULE_NAME = 'rimraf';
+
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
  * @typedef {import('../../types.js').CodemodOptions} CodemodOptions
@@ -27,7 +29,7 @@ const computeImport = (useRequire, quoteType, names, source) => {
  */
 export default function (options) {
 	return {
-		name: 'rimraf',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
 			const ast = ts.parse(file.source);

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -290,6 +290,35 @@ export function replaceDefaultImport(
 }
 
 /**
+ * Remove the import of a polyfill module and replace all references to its
+ * default import identifier with the given replacement string.
+ *
+ * Handles:
+ * - `import X from 'pkg'`
+ * - `const/var X = require('pkg')`
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} moduleName - The polyfill module to remove.
+ * @param {string} replacement - The replacement text for identifier references.
+ * @returns {{ edits: Edit[] }}
+ */
+export function replacePolyfillUsage(root, moduleName, replacement) {
+	const { edits, localNames } = removeImport(root, moduleName);
+	const identifierName = localNames[0];
+	if (!identifierName) return { edits };
+	const usages = root.findAll({
+		rule: {
+			kind: 'identifier',
+			pattern: identifierName,
+		},
+	});
+	for (const usage of usages) {
+		edits.push(usage.replace(replacement));
+	}
+	return { edits };
+}
+
+/**
  * Replace a default import/require of one package with a named import from another package.
  *
  * @param {SgNode} root - The root of the AST.

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -316,6 +316,7 @@ export function replacePolyfillUsage(root, moduleName, replacement) {
 		edits.push(usage.replace(replacement));
 	}
 	return { edits };
+}
 
 /**
  * Compute edits that replace every call of `identifierName(arg)` with

--- a/test/fixtures/abort-controller/case-2/after.js
+++ b/test/fixtures/abort-controller/case-2/after.js
@@ -1,0 +1,10 @@
+
+
+const controller = new AbortController();
+const signal = controller.signal;
+
+signal.addEventListener("abort", () => {
+  console.log("aborted!");
+});
+
+controller.abort();

--- a/test/fixtures/abort-controller/case-2/before.js
+++ b/test/fixtures/abort-controller/case-2/before.js
@@ -1,0 +1,10 @@
+import AbortControllerPolyfill from "abort-controller";
+
+const controller = new AbortControllerPolyfill();
+const signal = controller.signal;
+
+signal.addEventListener("abort", () => {
+  console.log("aborted!");
+});
+
+controller.abort();

--- a/test/fixtures/abort-controller/case-2/result.js
+++ b/test/fixtures/abort-controller/case-2/result.js
@@ -1,0 +1,10 @@
+
+
+const controller = new AbortController();
+const signal = controller.signal;
+
+signal.addEventListener("abort", () => {
+  console.log("aborted!");
+});
+
+controller.abort();

--- a/test/fixtures/math.acosh/case-1/after.js
+++ b/test/fixtures/math.acosh/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.acosh(1), 0);

--- a/test/fixtures/math.acosh/case-1/result.js
+++ b/test/fixtures/math.acosh/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.acosh(1), 0);

--- a/test/fixtures/math.atanh/case-1/after.js
+++ b/test/fixtures/math.atanh/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.atanh(0), 0);

--- a/test/fixtures/math.atanh/case-1/result.js
+++ b/test/fixtures/math.atanh/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.atanh(0), 0);

--- a/test/fixtures/math.cbrt/case-1/after.js
+++ b/test/fixtures/math.cbrt/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.cbrt(9), 3);

--- a/test/fixtures/math.cbrt/case-1/result.js
+++ b/test/fixtures/math.cbrt/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.cbrt(9), 3);

--- a/test/fixtures/math.clz32/case-1/after.js
+++ b/test/fixtures/math.clz32/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.clz32(1), 31);

--- a/test/fixtures/math.clz32/case-1/result.js
+++ b/test/fixtures/math.clz32/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.clz32(1), 31);

--- a/test/fixtures/math.f16round/case-1/after.js
+++ b/test/fixtures/math.f16round/case-1/after.js
@@ -1,3 +1,4 @@
+
 const assert = require("assert");
 
 assert.equal(Math.f16round(42.84), 42.84375);

--- a/test/fixtures/math.f16round/case-1/result.js
+++ b/test/fixtures/math.f16round/case-1/result.js
@@ -1,3 +1,4 @@
+
 const assert = require("assert");
 
 assert.equal(Math.f16round(42.84), 42.84375);

--- a/test/fixtures/math.fround/case-1/after.js
+++ b/test/fixtures/math.fround/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.fround(1.5), 1.5);

--- a/test/fixtures/math.fround/case-1/result.js
+++ b/test/fixtures/math.fround/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.fround(1.5), 1.5);

--- a/test/fixtures/math.imul/case-1/after.js
+++ b/test/fixtures/math.imul/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.imul(1, 2), 2);

--- a/test/fixtures/math.imul/case-1/result.js
+++ b/test/fixtures/math.imul/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.imul(1, 2), 2);

--- a/test/fixtures/math.log10/case-1/after.js
+++ b/test/fixtures/math.log10/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.log10(100), 2);

--- a/test/fixtures/math.log10/case-1/result.js
+++ b/test/fixtures/math.log10/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.log10(100), 2);

--- a/test/fixtures/math.log1p/case-1/after.js
+++ b/test/fixtures/math.log1p/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.log1p(0.007), 0.006975613736425242);

--- a/test/fixtures/math.log1p/case-1/result.js
+++ b/test/fixtures/math.log1p/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.log1p(0.007), 0.006975613736425242);

--- a/test/fixtures/math.sign/case-1/after.js
+++ b/test/fixtures/math.sign/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.sign(3), 1);

--- a/test/fixtures/math.sign/case-1/result.js
+++ b/test/fixtures/math.sign/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(Math.sign(3), 1);


### PR DESCRIPTION
### 🔗 Linked issue

See https://github.com/es-tooling/module-replacements-codemods/issues/111

### 📚 Description

- migrates `math.*` codemods to ast-grep
- adds `replacePolyfillUsage` util
- fixes `abort-controller` codemod
