### PR TITLE
feat: migrate `string.prototype.*` codemods to ast-grep

### DIFF
--- a/codemods/string.prototype.at/index.js
+++ b/codemods/string.prototype.at/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.at';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,15 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.at',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod('string.prototype.at', 'at', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'at',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.lastindexof/index.js
+++ b/codemods/string.prototype.lastindexof/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.lastindexof';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.lastindexof',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.lastindexof',
-				'lastIndexOf',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'lastIndexOf',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.matchall/index.js
+++ b/codemods/string.prototype.matchall/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.matchall';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -7,46 +12,38 @@ import { removeImport } from '../shared.js';
  */
 
 /**
- * @NOTE
- * `for-each` also supports passing objects to it, but this can't always be statically
- * analyzed. This codemod assumes usage of `for-each` on arrays only.
- *
- * If a project does use `for-each` on an object, you can replace it with `Object.entries(obj).forEach`
- *
  * @param {CodemodOptions} [options]
  * @returns {Codemod}
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.matchall',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('string.prototype.matchall', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.replaceWith(({ node }) => {
-					const args = node.arguments;
-					if (args.length === 2) {
-						const [string, ...otherArgs] = args;
+			if (!identifierName) {
+				return file.source;
+			}
 
-						return j.callExpression(
-							//@ts-ignore
-							j.memberExpression(string, j.identifier('matchAll')),
-							otherArgs,
-						);
-					}
-				});
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'matchAll',
+				(args) => args.length >= 1,
+			);
 
-			return root.toSource(options);
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.padend/index.js
+++ b/codemods/string.prototype.padend/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.padend';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.padend',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.padend',
-				'padEnd',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'padEnd',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.padleft/index.js
+++ b/codemods/string.prototype.padleft/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.padleft';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.padleft',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.padleft',
-				'padStart',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'padStart',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.padright/index.js
+++ b/codemods/string.prototype.padright/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.padright';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.padright',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.padright',
-				'padEnd',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'padEnd',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.padstart/index.js
+++ b/codemods/string.prototype.padstart/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.padstart';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.padstart',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.padstart',
-				'padStart',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'padStart',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.repeat/index.js
+++ b/codemods/string.prototype.repeat/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.repeat';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -7,46 +12,38 @@ import { removeImport } from '../shared.js';
  */
 
 /**
- * @NOTE
- * `for-each` also supports passing objects to it, but this can't always be statically
- * analyzed. This codemod assumes usage of `for-each` on arrays only.
- *
- * If a project does use `for-each` on an object, you can replace it with `Object.entries(obj).forEach`
- *
  * @param {CodemodOptions} [options]
  * @returns {Codemod}
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.repeat',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('string.prototype.repeat', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.replaceWith(({ node }) => {
-					const args = node.arguments;
-					if (args.length === 2) {
-						const [string, ...otherArgs] = args;
+			if (!identifierName) {
+				return file.source;
+			}
 
-						return j.callExpression(
-							//@ts-ignore
-							j.memberExpression(string, j.identifier('repeat')),
-							otherArgs,
-						);
-					}
-				});
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'repeat',
+				(args) => args.length >= 1,
+			);
 
-			return root.toSource(options);
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.replaceall/index.js
+++ b/codemods/string.prototype.replaceall/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.replaceall';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.replaceall',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.replaceall',
-				'replaceAll',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'replaceAll',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.split/index.js
+++ b/codemods/string.prototype.split/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.split';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.split',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.split',
-				'split',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'split',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.substr/index.js
+++ b/codemods/string.prototype.substr/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.substr';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.substr',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.substr',
-				'substr',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'substr',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.trim/index.js
+++ b/codemods/string.prototype.trim/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.trim';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.trim',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.trim',
-				'trim',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'trim',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.trimend/index.js
+++ b/codemods/string.prototype.trimend/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.trimend';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.trimend',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.trimend',
-				'trimEnd',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'trimEnd',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.trimleft/index.js
+++ b/codemods/string.prototype.trimleft/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.trimleft';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.trimleft',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.trimleft',
-				'trimStart',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'trimStart',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.trimright/index.js
+++ b/codemods/string.prototype.trimright/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.trimright';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.trimright',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.trimright',
-				'trimEnd',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'trimEnd',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/string.prototype.trimstart/index.js
+++ b/codemods/string.prototype.trimstart/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { transformStringMethod } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'string.prototype.trimstart';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,20 +17,33 @@ import { transformStringMethod } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'string.prototype.trimstart',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const dirty = transformStringMethod(
-				'string.prototype.trimstart',
-				'trimStart',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			return dirty ? root.toSource(options) : file.source;
+			if (!identifierName) {
+				return file.source;
+			}
+
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'trimStart',
+				(args) => args.length >= 1,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/string.prototype.at/case-1/after.js
+++ b/test/fixtures/string.prototype.at/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var str = "The quick brown fox jumps over the lazy dog.";

--- a/test/fixtures/string.prototype.at/case-1/result.js
+++ b/test/fixtures/string.prototype.at/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var str = "The quick brown fox jumps over the lazy dog.";

--- a/test/fixtures/string.prototype.lastindexof/case-1/after.js
+++ b/test/fixtures/string.prototype.lastindexof/case-1/after.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 assert("abcabc".lastIndexOf("abc") === 3);
 assert("abcabc".lastIndexOf("abc", 0) === 0);
 assert("abcabc".lastIndexOf("abc", 1) === 0);

--- a/test/fixtures/string.prototype.lastindexof/case-1/result.js
+++ b/test/fixtures/string.prototype.lastindexof/case-1/result.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 assert("abcabc".lastIndexOf("abc") === 3);
 assert("abcabc".lastIndexOf("abc", 0) === 0);
 assert("abcabc".lastIndexOf("abc", 1) === 0);

--- a/test/fixtures/string.prototype.matchall/case-1/after.js
+++ b/test/fixtures/string.prototype.matchall/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 const str = "aabc";
 const nonRegexStr = "ab";
 const globalRegex = /[ac]/g;

--- a/test/fixtures/string.prototype.matchall/case-1/result.js
+++ b/test/fixtures/string.prototype.matchall/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 const str = "aabc";
 const nonRegexStr = "ab";
 const globalRegex = /[ac]/g;

--- a/test/fixtures/string.prototype.padend/case-1/after.js
+++ b/test/fixtures/string.prototype.padend/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal("foo".padEnd(5, "bar"), "fooba");

--- a/test/fixtures/string.prototype.padend/case-1/result.js
+++ b/test/fixtures/string.prototype.padend/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal("foo".padEnd(5, "bar"), "fooba");

--- a/test/fixtures/string.prototype.padleft/case-1/after.js
+++ b/test/fixtures/string.prototype.padleft/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padStart(5, "bar") === "bafoo");

--- a/test/fixtures/string.prototype.padleft/case-1/result.js
+++ b/test/fixtures/string.prototype.padleft/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padStart(5, "bar") === "bafoo");

--- a/test/fixtures/string.prototype.padright/case-1/after.js
+++ b/test/fixtures/string.prototype.padright/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padEnd(5, "bar") === "fooba");

--- a/test/fixtures/string.prototype.padright/case-1/result.js
+++ b/test/fixtures/string.prototype.padright/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padEnd(5, "bar") === "fooba");

--- a/test/fixtures/string.prototype.padstart/case-1/after.js
+++ b/test/fixtures/string.prototype.padstart/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padStart(5, "bar") === "bafoo");

--- a/test/fixtures/string.prototype.padstart/case-1/result.js
+++ b/test/fixtures/string.prototype.padstart/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert("foo".padStart(5, "bar") === "bafoo");

--- a/test/fixtures/string.prototype.repeat/case-1/after.js
+++ b/test/fixtures/string.prototype.repeat/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 const input = "foo";

--- a/test/fixtures/string.prototype.repeat/case-1/result.js
+++ b/test/fixtures/string.prototype.repeat/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 const input = "foo";

--- a/test/fixtures/string.prototype.replaceall/case-1/after.js
+++ b/test/fixtures/string.prototype.replaceall/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 const str = "aabc";
 
 assert.equal(str.replaceAll(/a/g, "z"), str.replace(/a/g, "z"));

--- a/test/fixtures/string.prototype.replaceall/case-1/result.js
+++ b/test/fixtures/string.prototype.replaceall/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 const str = "aabc";
 
 assert.equal(str.replaceAll(/a/g, "z"), str.replace(/a/g, "z"));

--- a/test/fixtures/string.prototype.split/case-1/after.js
+++ b/test/fixtures/string.prototype.split/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.deepEqual("abc".split(""), ["a", "b", "c"]);

--- a/test/fixtures/string.prototype.split/case-1/result.js
+++ b/test/fixtures/string.prototype.split/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.deepEqual("abc".split(""), ["a", "b", "c"]);

--- a/test/fixtures/string.prototype.substr/case-1/after.js
+++ b/test/fixtures/string.prototype.substr/case-1/after.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 
+
 assert('abc'.substr(1) === 'bc');
 
 var str = 'abc';

--- a/test/fixtures/string.prototype.substr/case-1/result.js
+++ b/test/fixtures/string.prototype.substr/case-1/result.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 
+
 assert('abc'.substr(1) === 'bc');
 
 var str = 'abc';

--- a/test/fixtures/string.prototype.substr/case-2/after.js
+++ b/test/fixtures/string.prototype.substr/case-2/after.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 
+
 assert('abc'.substr(1) === 'bc');
 
 var str = 'abc';

--- a/test/fixtures/string.prototype.substr/case-2/result.js
+++ b/test/fixtures/string.prototype.substr/case-2/result.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 
+
 assert('abc'.substr(1) === 'bc');
 
 var str = 'abc';

--- a/test/fixtures/string.prototype.trim/case-1/after.js
+++ b/test/fixtures/string.prototype.trim/case-1/after.js
@@ -1,3 +1,4 @@
 var assert = require("assert");
 
+
 assert(" \t\na \t\n".trim() === "a");

--- a/test/fixtures/string.prototype.trim/case-1/result.js
+++ b/test/fixtures/string.prototype.trim/case-1/result.js
@@ -1,3 +1,4 @@
 var assert = require("assert");
 
+
 assert(" \t\na \t\n".trim() === "a");

--- a/test/fixtures/string.prototype.trimend/case-1/after.js
+++ b/test/fixtures/string.prototype.trimend/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimEnd() === " \t\na");

--- a/test/fixtures/string.prototype.trimend/case-1/result.js
+++ b/test/fixtures/string.prototype.trimend/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimEnd() === " \t\na");

--- a/test/fixtures/string.prototype.trimleft/case-1/after.js
+++ b/test/fixtures/string.prototype.trimleft/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimStart() === "a \t\n");

--- a/test/fixtures/string.prototype.trimleft/case-1/result.js
+++ b/test/fixtures/string.prototype.trimleft/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimStart() === "a \t\n");

--- a/test/fixtures/string.prototype.trimright/case-1/after.js
+++ b/test/fixtures/string.prototype.trimright/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimEnd() === " \t\na");

--- a/test/fixtures/string.prototype.trimright/case-1/result.js
+++ b/test/fixtures/string.prototype.trimright/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimEnd() === " \t\na");

--- a/test/fixtures/string.prototype.trimstart/case-1/after.js
+++ b/test/fixtures/string.prototype.trimstart/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimStart() === "a \t\n");

--- a/test/fixtures/string.prototype.trimstart/case-1/result.js
+++ b/test/fixtures/string.prototype.trimstart/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert(" \t\na \t\n".trimStart() === "a \t\n");


### PR DESCRIPTION
### 🔗 Linked issue

See https://github.com/es-tooling/module-replacements-codemods/issues/111

### 📚 Description

This migrates the `string.prototype.*` codemods to ast-grep
