### PR TITLE
feat: migrate `left-pad` and `pad-left` to ast-grep, add `computeCallReplacementEdits` util

### DIFF
--- a/codemods/array-buffer-byte-length/index.js
+++ b/codemods/array-buffer-byte-length/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'array-buffer-byte-length';
 
@@ -22,37 +25,16 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			const identifierName = localNames[0];
-
-			const callExpressions = root.findAll({
-				rule: {
-					pattern: `${identifierName}($$$ARG)`,
-				},
-			});
-
-			for (const call of callExpressions) {
-				const argsMatch = call.getMultipleMatches('ARG');
-				if (!argsMatch) continue;
-
-				const args = argsMatch.filter((m) => m.kind() !== ',');
-
-				if (args.length !== 1) continue;
-
-				const argNode = args[0];
-				const argText = argNode.text();
-
-				const isIdentifier = argNode.kind() === 'identifier';
-				const isNewArrayBuffer =
-					argNode.kind() === 'new_expression' &&
-					argText.startsWith('new ArrayBuffer');
-
-				if (isIdentifier || isNewArrayBuffer) {
-					edits.push(call.replace(`${argText}.byteLength`));
-				}
+			for (const identifierName of localNames) {
+				const callEdits = computeCallReplacementEdits(
+					root,
+					identifierName,
+					(args) => {
+						if (args.length !== 1) return null;
+						return `${args[0]}.byteLength`;
+					},
+				);
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/es-define-property/index.js
+++ b/codemods/es-define-property/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'es-define-property';
 
@@ -21,27 +24,14 @@ export default function (options) {
 			const root = ast.root();
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
-			const identifierName = localNames[0];
 
-			if (!identifierName) {
-				return edits.length > 0 ? root.commitEdits(edits) : file.source;
-			}
-
-			const calls = root.findAll({
-				rule: {
-					pattern: `${identifierName}($$$ARGS)`,
-				},
-			});
-
-			for (const call of calls) {
-				const argsMatch = call.getMultipleMatches('ARGS');
-				const argsText = argsMatch
-					? argsMatch
-							.filter((m) => m.kind() !== ',')
-							.map((m) => m.text())
-							.join(', ')
-					: '';
-				edits.push(call.replace(`Object.defineProperty(${argsText})`));
+			for (const identifierName of localNames) {
+				const callEdits = computeCallReplacementEdits(
+					root,
+					identifierName,
+					(args) => `Object.defineProperty(${args.join(', ')})`,
+				);
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-array-buffer/index.js
+++ b/codemods/is-array-buffer/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-array-buffer';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `(${args[0]} instanceof ArrayBuffer)`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `(${argText} instanceof ArrayBuffer)`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-boolean-object/index.js
+++ b/codemods/is-boolean-object/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-boolean-object';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `Object.prototype.toString.call(${args[0]}) === '[object Boolean]'`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `Object.prototype.toString.call(${argText}) === '[object Boolean]'`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-date-object/index.js
+++ b/codemods/is-date-object/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-date-object';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `Object.prototype.toString.call(${args[0]}) === '[object Date]'`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `Object.prototype.toString.call(${argText}) === '[object Date]'`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-even/index.js
+++ b/codemods/is-even/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-even';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `(${args[0]} % 2 === 0)`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `(${argText} % 2 === 0)`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-negative-zero/index.js
+++ b/codemods/is-negative-zero/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-negative-zero';
 
@@ -42,20 +45,15 @@ export default function (options) {
 				}
 
 				// Find remaining localName(...) calls and replace with Object.is(arg, -0)
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
+				const callEdits = computeCallReplacementEdits(
+					root,
+					localName,
+					(args) => {
+						if (args.length !== 1) return null;
+						return `Object.is(${args[0]}, -0)`;
 					},
-				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-					const argText = args[0].text();
-					edits.push(call.replace(`Object.is(${argText}, -0)`));
-				}
+				);
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-number/index.js
+++ b/codemods/is-number/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-number';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `(typeof ${args[0]} === 'number' || typeof ${args[0]} === 'string' && Number.isFinite(+${args[0]}))`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `(typeof ${argText} === 'number' || typeof ${argText} === 'string' && Number.isFinite(+${argText}))`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-odd/index.js
+++ b/codemods/is-odd/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-odd';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `(${args[0]} % 2 !== 0)`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `(${argText} % 2 !== 0)`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-regexp/index.js
+++ b/codemods/is-regexp/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-regexp';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `(${args[0]} instanceof RegExp)`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `(${argText} instanceof RegExp)`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-string/index.js
+++ b/codemods/is-string/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-string';
 
@@ -22,28 +25,12 @@ export default function (options) {
 
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `Object.prototype.toString.call(${args[0]}) === '[object String]'`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-
-					const argText = args[0].text();
-					const replacement = `Object.prototype.toString.call(${argText}) === '[object String]'`;
-					edits.push(call.replace(replacement));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/is-whitespace/index.js
+++ b/codemods/is-whitespace/index.js
@@ -1,5 +1,8 @@
 import { ts } from '@ast-grep/napi';
-import { removeImport } from '../shared-ast-grep.js';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
 
 const MODULE_NAME = 'is-whitespace';
 
@@ -21,25 +24,12 @@ export default function (options) {
 			const root = ast.root();
 			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (localNames.length === 0) {
-				return file.source;
-			}
-
-			for (const localName of localNames) {
-				const calls = root.findAll({
-					rule: {
-						pattern: `${localName}($$$ARGS)`,
-					},
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					if (args.length !== 1) return null;
+					return `${args[0]}.trim() === ''`;
 				});
-
-				for (const call of calls) {
-					const argsMatch = call.getMultipleMatches('ARGS');
-					if (!argsMatch) continue;
-					const args = argsMatch.filter((m) => m.kind() !== ',');
-					if (args.length !== 1) continue;
-					const argText = args[0].text();
-					edits.push(call.replace(`${argText}.trim() === ''`));
-				}
+				edits.push(...callEdits);
 			}
 
 			return edits.length > 0 ? root.commitEdits(edits) : file.source;

--- a/codemods/left-pad/index.js
+++ b/codemods/left-pad/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'left-pad';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,36 +20,20 @@ export default function (options) {
 		name: 'left-pad',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('left-pad', root, j);
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.replaceWith(({ node }) => {
-					const [stringArg, ...otherArgs] = node.arguments;
-					return j.callExpression(
-						j.memberExpression(
-							j.callExpression(
-								j.memberExpression(
-									// @ts-ignore
-									j.parenthesizedExpression(stringArg),
-									j.identifier('toString'),
-								),
-								[],
-							),
-							j.identifier('padStart'),
-						),
-						[...otherArgs],
-					);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
+
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					const [first, ...rest] = args;
+					return `(${first}).toString().padStart(${rest.join(', ')})`;
 				});
+				edits.push(...callEdits);
+			}
 
-			return root.toSource(options);
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/pad-left/index.js
+++ b/codemods/pad-left/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'pad-left';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -15,36 +20,20 @@ export default function (options) {
 		name: 'pad-left',
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('pad-left', root, j);
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.replaceWith(({ node }) => {
-					const [stringArg, ...otherArgs] = node.arguments;
-					return j.callExpression(
-						j.memberExpression(
-							j.callExpression(
-								j.memberExpression(
-									// @ts-ignore
-									j.parenthesizedExpression(stringArg),
-									j.identifier('toString'),
-								),
-								[],
-							),
-							j.identifier('padStart'),
-						),
-						[...otherArgs],
-					);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
+
+			for (const name of localNames) {
+				const callEdits = computeCallReplacementEdits(root, name, (args) => {
+					const [first, ...rest] = args;
+					return `(${first}).toString().padStart(${rest.join(', ')})`;
 				});
+				edits.push(...callEdits);
+			}
 
-			return root.toSource(options);
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -441,18 +441,10 @@ export function computePolyfillPropertyReplacementEdits(
 	identifierName,
 	propertyName,
 ) {
-	/** @type {Edit[]} */
-	const edits = [];
-	const calls = root.findAll({
-		rule: { pattern: `${identifierName}($ARG)` },
+	return computeCallReplacementEdits(root, identifierName, (args) => {
+		if (args.length !== 1) return null;
+		return `${args[0]}.${propertyName}`;
 	});
-	for (const call of calls) {
-		const arg = call.getMatch('ARG');
-		if (arg) {
-			edits.push(call.replace(`${arg.text()}.${propertyName}`));
-		}
-	}
-	return edits;
 }
 
 /**

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -251,10 +251,11 @@ export function findDefaultImportIdentifier(root, moduleName) {
 /**
  * Low-level helper that finds all calls to `fromIdentifier(...)` and applies
  * a custom format callback to produce the replacement text for each call.
+ * Return `null` from the callback to skip a call without producing an edit.
  *
  * @param {SgNode} root - The root of the AST.
  * @param {string} fromIdentifier - The identifier currently being called.
- * @param {(args: string[]) => string} formatReplacement - Receives the argument texts and returns the full replacement string.
+ * @param {(args: string[]) => string | null} formatReplacement - Receives the argument texts and returns the replacement string, or null to skip.
  * @returns {Edit[]}
  */
 export function computeCallReplacementEdits(
@@ -274,7 +275,9 @@ export function computeCallReplacementEdits(
 		const args = argsMatch
 			? argsMatch.filter((m) => m.kind() !== ',').map((m) => m.text())
 			: [];
-		edits.push(call.replace(formatReplacement(args)));
+		const replacement = formatReplacement(args);
+		if (replacement === null) continue;
+		edits.push(call.replace(replacement));
 	}
 	return edits;
 }

--- a/codemods/shared-ast-grep.js
+++ b/codemods/shared-ast-grep.js
@@ -249,6 +249,37 @@ export function findDefaultImportIdentifier(root, moduleName) {
 }
 
 /**
+ * Low-level helper that finds all calls to `fromIdentifier(...)` and applies
+ * a custom format callback to produce the replacement text for each call.
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} fromIdentifier - The identifier currently being called.
+ * @param {(args: string[]) => string} formatReplacement - Receives the argument texts and returns the full replacement string.
+ * @returns {Edit[]}
+ */
+export function computeCallReplacementEdits(
+	root,
+	fromIdentifier,
+	formatReplacement,
+) {
+	/** @type {Edit[]} */
+	const edits = [];
+	const calls = root.findAll({
+		rule: {
+			pattern: `${fromIdentifier}($$$ARGS)`,
+		},
+	});
+	for (const call of calls) {
+		const argsMatch = call.getMultipleMatches('ARGS');
+		const args = argsMatch
+			? argsMatch.filter((m) => m.kind() !== ',').map((m) => m.text())
+			: [];
+		edits.push(call.replace(formatReplacement(args)));
+	}
+	return edits;
+}
+
+/**
  * Compute edits that replace every call of `fromIdentifier(...)` with
  * `toCallee(...)`, preserving the original argument list verbatim.
  *
@@ -262,24 +293,11 @@ export function computeSimpleCallReplacementEdits(
 	fromIdentifier,
 	toCallee,
 ) {
-	/** @type {Edit[]} */
-	const edits = [];
-	const calls = root.findAll({
-		rule: {
-			pattern: `${fromIdentifier}($$$ARGS)`,
-		},
-	});
-	for (const call of calls) {
-		const argsMatch = call.getMultipleMatches('ARGS');
-		const argsText = argsMatch
-			? argsMatch
-					.filter((m) => m.kind() !== ',')
-					.map((m) => m.text())
-					.join(', ')
-			: '';
-		edits.push(call.replace(`${toCallee}(${argsText})`));
-	}
-	return edits;
+	return computeCallReplacementEdits(
+		root,
+		fromIdentifier,
+		(args) => `${toCallee}(${args.join(', ')})`,
+	);
 }
 
 /**

--- a/test/fixtures/left-pad/case-1/after.js
+++ b/test/fixtures/left-pad/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(("foo").toString().padStart(5), "foo  ");

--- a/test/fixtures/left-pad/case-1/result.js
+++ b/test/fixtures/left-pad/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(("foo").toString().padStart(5), "foo  ");

--- a/test/fixtures/pad-left/case-1/after.js
+++ b/test/fixtures/pad-left/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(("foo").toString().padStart(5), "foo  ");

--- a/test/fixtures/pad-left/case-1/result.js
+++ b/test/fixtures/pad-left/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(("foo").toString().padStart(5), "foo  ");

--- a/types/codemods/shared-ast-grep.d.ts
+++ b/types/codemods/shared-ast-grep.d.ts
@@ -49,6 +49,17 @@ export function findDefaultImportIdentifier(root: SgNode, moduleName: string): {
     identifierName: string | null;
 };
 /**
+ * Low-level helper that finds all calls to `fromIdentifier(...)` and applies
+ * a custom format callback to produce the replacement text for each call.
+ * Return `null` from the callback to skip a call without producing an edit.
+ *
+ * @param {SgNode} root - The root of the AST.
+ * @param {string} fromIdentifier - The identifier currently being called.
+ * @param {(args: string[]) => string | null} formatReplacement - Receives the argument texts and returns the replacement string, or null to skip.
+ * @returns {Edit[]}
+ */
+export function computeCallReplacementEdits(root: SgNode, fromIdentifier: string, formatReplacement: (args: string[]) => string | null): Edit[];
+/**
  * Compute edits that replace every call of `fromIdentifier(...)` with
  * `toCallee(...)`, preserving the original argument list verbatim.
  *


### PR DESCRIPTION
### 🔗 Linked issue

See #111
Closes #110

### 📚 Description

This migrates the `left-pad` and `pad-left` codemods to use ast-grep

Adds shared `computeCallReplacementEdits` util 

- refactors other codemods to use `computeCallReplacementEdits`, where relevant