### PR TITLE
feat: migrate `has-*` codemods to ast-grep

### DIFF
--- a/codemods/has-own-prop/index.js
+++ b/codemods/has-own-prop/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeSimpleCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'has-own-prop';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,34 +17,32 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'has-own-prop',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('has-own-prop', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					const newExpression = j.callExpression(
-						j.memberExpression(j.identifier('Object'), j.identifier('hasOwn')),
-						//@ts-ignore
-						args,
-					);
-					j(path).replaceWith(newExpression);
-					dirtyFlag = true;
-				});
+			if (!identifierName) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			const edits = computeSimpleCallReplacementEdits(
+				root,
+				identifierName,
+				'Object.hasOwn',
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/has-proto/index.js
+++ b/codemods/has-proto/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { removeImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'has-proto';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,30 +14,26 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'has-proto',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('has-proto', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
+			for (const name of localNames) {
+				const calls = root.findAll({
+					rule: {
+						pattern: `${name}($$$ARGS)`,
 					},
-				})
-				.forEach((path) => {
-					const newExpression = j.booleanLiteral(true);
-
-					j(path).replaceWith(newExpression);
-					dirtyFlag = true;
 				});
+				for (const call of calls) {
+					edits.push(call.replace('true'));
+				}
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/has-symbols/index.js
+++ b/codemods/has-symbols/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { removeImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'has-symbols';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,35 +14,29 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'has-symbols',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('has-symbols', root, j);
-			const { identifier: identifierShams } = removeImport(
-				'has-symbols/shams',
-				root,
-				j,
-			);
-			[identifier, identifierShams].forEach((identifier) => {
-				root
-					.find(j.CallExpression, {
-						callee: {
-							type: 'Identifier',
-							name: identifier,
-						},
-					})
-					.forEach((path) => {
-						const newExpression = j.booleanLiteral(true);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
+			const shams = removeImport(root, `${MODULE_NAME}/shams`);
+			edits.push(...shams.edits);
+			const allNames = [...localNames, ...shams.localNames];
 
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					});
-			});
-			return dirtyFlag ? root.toSource(options) : file.source;
+			for (const name of allNames) {
+				const calls = root.findAll({
+					rule: {
+						pattern: `${name}($$$ARGS)`,
+					},
+				});
+				for (const call of calls) {
+					edits.push(call.replace('true'));
+				}
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/has-tostringtag/index.js
+++ b/codemods/has-tostringtag/index.js
@@ -1,5 +1,7 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import { removeImport } from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'has-tostringtag';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,35 +14,29 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'has-tostringtag',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('has-tostringtag', root, j);
-			const { identifier: identifierShams } = removeImport(
-				'has-tostringtag/shams',
-				root,
-				j,
-			);
-			[identifier, identifierShams].forEach((identifier) => {
-				root
-					.find(j.CallExpression, {
-						callee: {
-							type: 'Identifier',
-							name: identifier,
-						},
-					})
-					.forEach((path) => {
-						const newExpression = j.booleanLiteral(true);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
+			const shams = removeImport(root, `${MODULE_NAME}/shams`);
+			edits.push(...shams.edits);
+			const allNames = [...localNames, ...shams.localNames];
 
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					});
-			});
-			return dirtyFlag ? root.toSource(options) : file.source;
+			for (const name of allNames) {
+				const calls = root.findAll({
+					rule: {
+						pattern: `${name}($$$ARGS)`,
+					},
+				});
+				for (const call of calls) {
+					edits.push(call.replace('true'));
+				}
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/hasown/index.js
+++ b/codemods/hasown/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeSimpleCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'hasown';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,34 +17,32 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'hasown',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('hasown', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					const newExpression = j.callExpression(
-						j.memberExpression(j.identifier('Object'), j.identifier('hasOwn')),
-						//@ts-ignore
-						args,
-					);
-					j(path).replaceWith(newExpression);
-					dirtyFlag = true;
-				});
+			if (!identifierName) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			const edits = computeSimpleCallReplacementEdits(
+				root,
+				identifierName,
+				'Object.hasOwn',
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/has-own-prop/case-1/after.js
+++ b/test/fixtures/has-own-prop/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(Object.hasOwn({}, "toString"), false);
 assert.equal(Object.hasOwn([], "length"), true);
 assert.equal(Object.hasOwn({ a: 42 }, "a"), true);

--- a/test/fixtures/has-own-prop/case-1/result.js
+++ b/test/fixtures/has-own-prop/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(Object.hasOwn({}, "toString"), false);
 assert.equal(Object.hasOwn([], "length"), true);
 assert.equal(Object.hasOwn({ a: 42 }, "a"), true);

--- a/test/fixtures/has-proto/case-1/after.js
+++ b/test/fixtures/has-proto/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(typeof true, "boolean");

--- a/test/fixtures/has-proto/case-1/result.js
+++ b/test/fixtures/has-proto/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 assert.equal(typeof true, "boolean");

--- a/test/fixtures/has-symbols/case-1/after.js
+++ b/test/fixtures/has-symbols/case-1/after.js
@@ -1,3 +1,5 @@
+
 true === true;
+
 
 true === true;

--- a/test/fixtures/has-symbols/case-1/result.js
+++ b/test/fixtures/has-symbols/case-1/result.js
@@ -1,3 +1,5 @@
+
 true === true;
+
 
 true === true;

--- a/test/fixtures/has-tostringtag/case-1/after.js
+++ b/test/fixtures/has-tostringtag/case-1/after.js
@@ -1,3 +1,5 @@
+
 true === true;
+
 
 true === true;

--- a/test/fixtures/has-tostringtag/case-1/result.js
+++ b/test/fixtures/has-tostringtag/case-1/result.js
@@ -1,3 +1,5 @@
+
 true === true;
+
 
 true === true;

--- a/test/fixtures/hasown/case-1/after.js
+++ b/test/fixtures/hasown/case-1/after.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(Object.hasOwn({}, "toString"), false);
 assert.equal(Object.hasOwn([], "length"), true);
 assert.equal(Object.hasOwn({ a: 42 }, "a"), true);

--- a/test/fixtures/hasown/case-1/result.js
+++ b/test/fixtures/hasown/case-1/result.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 
+
 assert.equal(Object.hasOwn({}, "toString"), false);
 assert.equal(Object.hasOwn([], "length"), true);
 assert.equal(Object.hasOwn({ a: 42 }, "a"), true);


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `has-*` codemods to ast-grep
