### PR TITLE
feat: migrate `promise.*` codemods to ast-grep

### DIFF
--- a/codemods/promise.allsettled/index.js
+++ b/codemods/promise.allsettled/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeSimpleCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'promise.allsettled';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,38 +17,32 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'promise.allsettled',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('promise.allsettled', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 1) {
-						const newExpression = j.callExpression(
-							j.memberExpression(
-								j.identifier('Promise'),
-								j.identifier('allSettled'),
-							),
-							args,
-						);
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					}
-				});
+			if (!identifierName) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			const edits = computeSimpleCallReplacementEdits(
+				root,
+				identifierName,
+				'Promise.allSettled',
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/promise.any/index.js
+++ b/codemods/promise.any/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeSimpleCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'promise.any';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,35 +17,32 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'promise.any',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('promise.any', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 1) {
-						const newExpression = j.callExpression(
-							j.memberExpression(j.identifier('Promise'), j.identifier('any')),
-							args,
-						);
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					}
-				});
+			if (!identifierName) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			const edits = computeSimpleCallReplacementEdits(
+				root,
+				identifierName,
+				'Promise.any',
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/codemods/promise.prototype.finally/index.js
+++ b/codemods/promise.prototype.finally/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'promise.prototype.finally';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,37 +17,33 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'promise.prototype.finally',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('promise.prototype.finally', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 2) {
-						const [promise, callback] = args;
-						const newExpression = j.callExpression(
-							//@ts-ignore
-							j.memberExpression(promise, j.identifier('finally')),
-							[callback],
-						);
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					}
-				});
+			if (!identifierName) {
+				return file.source;
+			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'finally',
+				(args) => args.length === 2,
+			);
+
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/promise.allsettled/case-1/after.js
+++ b/test/fixtures/promise.allsettled/case-1/after.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 

--- a/test/fixtures/promise.allsettled/case-1/result.js
+++ b/test/fixtures/promise.allsettled/case-1/result.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 

--- a/test/fixtures/promise.any/case-1/after.js
+++ b/test/fixtures/promise.any/case-1/after.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 var alsoRejected = Promise.reject(Infinity);

--- a/test/fixtures/promise.any/case-1/result.js
+++ b/test/fixtures/promise.any/case-1/result.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 var alsoRejected = Promise.reject(Infinity);

--- a/test/fixtures/promise.prototype.finally/case-1/after.js
+++ b/test/fixtures/promise.prototype.finally/case-1/after.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 

--- a/test/fixtures/promise.prototype.finally/case-1/result.js
+++ b/test/fixtures/promise.prototype.finally/case-1/result.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 
+
 var resolved = Promise.resolve(42);
 var rejected = Promise.reject(-1);
 


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `promise.*` codemods to ast-grep
