### PR TITLE
feat: migrate `setprototypeof` to ast-grep

### DIFF
--- a/codemods/setprototypeof/index.js
+++ b/codemods/setprototypeof/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computeSimpleCallReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'setprototypeof';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,35 +17,24 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'setprototypeof',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('setprototypeof', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			if (identifier) {
-				const callExpressions = root.find(j.CallExpression, {
-					callee: { name: identifier },
-				});
-
-				for (const path of callExpressions.paths()) {
-					j(path).replaceWith(
-						j.callExpression(
-							j.memberExpression(
-								j.identifier('Object'),
-								j.identifier('setPrototypeOf'),
-							),
-							path.node.arguments,
-						),
-					);
-					dirtyFlag = true;
-				}
+			for (const name of localNames) {
+				const callEdits = computeSimpleCallReplacementEdits(
+					root,
+					name,
+					'Object.setPrototypeOf',
+				);
+				edits.push(...callEdits);
 			}
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/setprototypeof/case-1/after.js
+++ b/test/fixtures/setprototypeof/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 function Foo() { }

--- a/test/fixtures/setprototypeof/case-1/result.js
+++ b/test/fixtures/setprototypeof/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 function Foo() { }

--- a/test/fixtures/setprototypeof/case-2/after.js
+++ b/test/fixtures/setprototypeof/case-2/after.js
@@ -1,3 +1,4 @@
+
 import assert from 'assert';
 
 function Foo() { }

--- a/test/fixtures/setprototypeof/case-2/result.js
+++ b/test/fixtures/setprototypeof/case-2/result.js
@@ -1,3 +1,4 @@
+
 import assert from 'assert';
 
 function Foo() { }


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `setprototypeof` codemod to use ast-grep
