### PR TITLE
feat: migrate `for-each` to ast-grep

### DIFF
--- a/codemods/for-each/index.js
+++ b/codemods/for-each/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'for-each';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -18,38 +23,33 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'for-each',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('for-each', root, j);
+			const { imports, identifierName } = findDefaultImportIdentifier(
+				root,
+				MODULE_NAME,
+			);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 2) {
-						const [array, callback] = args;
+			if (!identifierName) {
+				return file.source;
+			}
 
-						const newExpression = j.callExpression(
-							//@ts-ignore
-							j.memberExpression(array, j.identifier('forEach')),
-							[callback],
-						);
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					}
-				});
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'forEach',
+				(args) => args.length === 2,
+			);
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/for-each/case-1/after.js
+++ b/test/fixtures/for-each/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 var a = [1, 2, 3];

--- a/test/fixtures/for-each/case-1/result.js
+++ b/test/fixtures/for-each/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 var a = [1, 2, 3];

--- a/test/fixtures/for-each/case-2/after.js
+++ b/test/fixtures/for-each/case-2/after.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(

--- a/test/fixtures/for-each/case-2/before.js
+++ b/test/fixtures/for-each/case-2/before.js
@@ -1,5 +1,5 @@
-var forEach = require('for-each');
-var assert = require('assert');
+import forEach from 'for-each';
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(

--- a/test/fixtures/for-each/case-2/result.js
+++ b/test/fixtures/for-each/case-2/result.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(

--- a/test/fixtures/for-each/case-3/after.js
+++ b/test/fixtures/for-each/case-3/after.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 var a = [1, 2, 3];

--- a/test/fixtures/for-each/case-3/result.js
+++ b/test/fixtures/for-each/case-3/result.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 
 var a = [1, 2, 3];

--- a/test/fixtures/for-each/case-4/after.js
+++ b/test/fixtures/for-each/case-4/after.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(

--- a/test/fixtures/for-each/case-4/before.js
+++ b/test/fixtures/for-each/case-4/before.js
@@ -1,5 +1,5 @@
-var banana = require('for-each');
-var assert = require('assert');
+import banana from 'for-each';
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(

--- a/test/fixtures/for-each/case-4/result.js
+++ b/test/fixtures/for-each/case-4/result.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+
+import assert from 'assert';
 
 var a = [1, 2, 3];
 assert.equal(


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `for-each` codemod to use ast-grep

Also replaced duplicate test fixtures with ESM variants tests