### PR TITLE
feat: migrate `arraybuffer.prototype.slice` to ast-grep

### DIFF
--- a/codemods/arraybuffer.prototype.slice/index.js
+++ b/codemods/arraybuffer.prototype.slice/index.js
@@ -1,5 +1,10 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillMethodCallReplacementEdits,
+	findDefaultImportIdentifier,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'arraybuffer.prototype.slice';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,46 +17,33 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'arraybuffer.prototype.slice',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport(
-				'arraybuffer.prototype.slice',
+			const { imports, identifierName } = findDefaultImportIdentifier(
 				root,
-				j,
+				MODULE_NAME,
 			);
 
-			let dirtyFlag = false;
+			if (!identifierName) {
+				return file.source;
+			}
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const [bufferArg, ...otherArgs] = path.node.arguments;
-					if (
-						j.Identifier.check(bufferArg) ||
-						(j.NewExpression.check(bufferArg) &&
-							bufferArg.callee.type === 'Identifier' &&
-							bufferArg.callee.name === 'ArrayBuffer')
-					) {
-						path.replace(
-							j.callExpression(
-								j.memberExpression(bufferArg, j.identifier('slice')),
-								otherArgs,
-							),
-						);
-						dirtyFlag = true;
-					}
-				});
+			const edits = computePolyfillMethodCallReplacementEdits(
+				root,
+				identifierName,
+				'slice',
+				(args) => args.length >= 1,
+			);
 
-			return dirtyFlag ? root.toSource(options) : file.source;
+			for (const imp of imports) {
+				edits.push(imp.replace(''));
+			}
+
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/arraybuffer.prototype.slice/case-1/after.js
+++ b/test/fixtures/arraybuffer.prototype.slice/case-1/after.js
@@ -1,3 +1,5 @@
+
+
 const buffer = new ArrayBuffer(16);
 
 const sliced1 = new Int32Array(buffer.slice(4, 12));

--- a/test/fixtures/arraybuffer.prototype.slice/case-1/result.js
+++ b/test/fixtures/arraybuffer.prototype.slice/case-1/result.js
@@ -1,3 +1,5 @@
+
+
 const buffer = new ArrayBuffer(16);
 
 const sliced1 = new Int32Array(buffer.slice(4, 12));


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `arraybuffer.prototype.slice` codemod to use ast-grep
