### PR TITLE
feat: migrate `get-symbol-description` to ast-grep

### DIFF
--- a/codemods/get-symbol-description/index.js
+++ b/codemods/get-symbol-description/index.js
@@ -1,5 +1,11 @@
-import jscodeshift from 'jscodeshift';
-import { removeImport } from '../shared.js';
+import { ts } from '@ast-grep/napi';
+import {
+	computePolyfillPropertyReplacementEdits,
+	removeImport,
+} from '../shared-ast-grep.js';
+
+const MODULE_NAME = 'get-symbol-description';
+const PROPERTY_NAME = 'description';
 
 /**
  * @typedef {import('../../types.js').Codemod} Codemod
@@ -12,37 +18,24 @@ import { removeImport } from '../shared.js';
  */
 export default function (options) {
 	return {
-		name: 'get-symbol-description',
+		name: MODULE_NAME,
 		to: 'native',
 		transform: ({ file }) => {
-			const j = jscodeshift;
-			const root = j(file.source);
-			let dirtyFlag = false;
+			const ast = ts.parse(file.source);
+			const root = ast.root();
 
-			const { identifier } = removeImport('get-symbol-description', root, j);
+			const { edits, localNames } = removeImport(root, MODULE_NAME);
 
-			root
-				.find(j.CallExpression, {
-					callee: {
-						type: 'Identifier',
-						name: identifier,
-					},
-				})
-				.forEach((path) => {
-					const args = path.value.arguments;
-					if (args.length === 1) {
-						const newExpression = j.memberExpression(
-							//@ts-ignore
-							args[0],
-							j.identifier('description'),
-						);
+			for (const name of localNames) {
+				const propEdits = computePolyfillPropertyReplacementEdits(
+					root,
+					name,
+					PROPERTY_NAME,
+				);
+				edits.push(...propEdits);
+			}
 
-						j(path).replaceWith(newExpression);
-						dirtyFlag = true;
-					}
-				});
-
-			return dirtyFlag ? root.toSource(options) : file.source;
+			return edits.length > 0 ? root.commitEdits(edits) : file.source;
 		},
 	};
 }

--- a/test/fixtures/get-symbol-description/case-1/after.js
+++ b/test/fixtures/get-symbol-description/case-1/after.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var testSymbol = symbol("foo");

--- a/test/fixtures/get-symbol-description/case-1/result.js
+++ b/test/fixtures/get-symbol-description/case-1/result.js
@@ -1,3 +1,4 @@
+
 var assert = require("assert");
 
 var testSymbol = symbol("foo");


### PR DESCRIPTION
### 🔗 Linked issue

See #111

### 📚 Description

This migrates the `get-symbol-description` codemod to use ast-grep
